### PR TITLE
[feature] start-game 핸들러 구현

### DIFF
--- a/backend/src/core/core.gateway.ts
+++ b/backend/src/core/core.gateway.ts
@@ -47,4 +47,21 @@ export class CoreGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
         client.broadcast.to(lobbyId).emit('join-lobby', client);
         return lobby.players;
     }
+
+    @SubscribeMessage('game-start')
+    async handleGameStart(@ConnectedSocket() client: Socket, @MessageBody() lobbyId: string) {
+        const lobby = this.lobbyService.getLobby(lobbyId);
+        if (lobby === undefined)
+            // TODO: 소켓 클라이언트에게 에러 전달 방법(에러 핸들링) 확인 필요.
+            throw new Error('Lobby not found');
+        if (this.lobbyService.isLobbyOwner(client, lobbyId))
+            throw new Error('Only owner can start game');
+        // TODO: GameStart 로직 처리 (게임 시작시 게임의 상태 정보 변경)
+        // TODO: gameMock 데이터 대신 실제 게임 데이터로 변경 필요
+        const gameMock = {
+            id: lobbyId,
+            players: lobby.players,
+        };
+        client.nsp.to(lobbyId).emit('game-start', gameMock);
+    }
 }

--- a/backend/src/core/lobby.service.ts
+++ b/backend/src/core/lobby.service.ts
@@ -34,6 +34,14 @@ export class LobbyService {
         return lobby.players;
     }
 
+    isLobbyOwner(client: Socket, lobbyId: string): boolean {
+        const lobby = this.getLobby(lobbyId);
+        if (lobby === undefined) {
+            return false;
+        }
+        return lobby.owner === client.id;
+    }
+
     getLobby(lobbyId: string): Lobby | undefined {
         return this.store[lobbyId];
     }


### PR DESCRIPTION
## 상세내용
* gameStart 시 game 상태 관리 로직은 현재 주석처리로 비워둠 -> 추후 추가 구현 필요
* gameStart 시 로비에 들어가있는 클라이언트들에게 게임 정보를 보내줌 -> 게임 정보는 현재 mock 처리 나중에 수정 필요.
