### PR TITLE
Feat/main socket

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -1,29 +1,30 @@
 module.exports = {
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    project: 'tsconfig.json',
-    tsconfigRootDir: __dirname,
-    sourceType: 'module',
-  },
-  plugins: ['@typescript-eslint/eslint-plugin', 'prettier'],
-  extends: [
-    'standard-with-typescript',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
-  ],
-  root: true,
-  env: {
-    node: true,
-    jest: true,
-    browser: true,
-    es2021: true,
-  },
-  ignorePatterns: ['.eslintrc.js'],
-  rules: {
-    '@typescript-eslint/interface-name-prefix': 'off',
-    '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/strict-boolean-expressions': 'off',
-  },
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        project: 'tsconfig.json',
+        tsconfigRootDir: __dirname,
+        sourceType: 'module',
+    },
+    plugins: ['@typescript-eslint/eslint-plugin', 'prettier'],
+    extends: [
+        'standard-with-typescript',
+        'plugin:@typescript-eslint/recommended',
+        'plugin:prettier/recommended',
+    ],
+    root: true,
+    env: {
+        node: true,
+        jest: true,
+        browser: true,
+        es2021: true,
+    },
+    ignorePatterns: ['.eslintrc.js'],
+    rules: {
+        '@typescript-eslint/interface-name-prefix': 'off',
+        '@typescript-eslint/explicit-function-return-type': 'off',
+        '@typescript-eslint/explicit-module-boundary-types': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/strict-boolean-expressions': 'off',
+        '@typescript-eslint/no-non-null-assertion': 'off',
+    },
 };

--- a/backend/src/core/core.gateway.ts
+++ b/backend/src/core/core.gateway.ts
@@ -14,7 +14,7 @@ import { UsePipes, ValidationPipe } from '@nestjs/common';
 import { JoinLobbyRequest, CreateLobbyRequest } from './user.dto';
 import { UserService } from './user.service';
 
-@UsePipes(new ValidationPipe())
+// @UsePipes(new ValidationPipe())
 @WebSocketGateway(8180, { namespace: 'core' })
 export class CoreGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
     constructor(
@@ -41,7 +41,7 @@ export class CoreGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
         @MessageBody() body: CreateLobbyRequest,
     ) {
         // TODO: socket connection 라이프 사이클에 user 생성, 삭제 로직 할당
-        const user = this.userService.createUser(body.userName, client.id);
+        const user = this.userService.createUser(client.id, body.userName);
         const lobbyId = this.lobbyService.createLobby(user);
         await client.join(lobbyId);
         return lobbyId;

--- a/backend/src/core/core.gateway.ts
+++ b/backend/src/core/core.gateway.ts
@@ -11,9 +11,15 @@ import {
 import { Socket } from 'socket.io';
 import { LobbyService } from './lobby.service';
 import { UsePipes, ValidationPipe } from '@nestjs/common';
-import { JoinLobbyRequest, CreateLobbyRequest } from './user.dto';
+import {
+    JoinLobbyRequest,
+    CreateLobbyRequest,
+    JoinLobbyResponse,
+    JoinLobbyReEmitRequest,
+} from './user.dto';
 import { UserService } from './user.service';
 
+// TODO: Validation Pipe 관련 내용 학습 + 소켓에서 에러 처리 어케할건지 학습 하고 적용하기
 // @UsePipes(new ValidationPipe())
 @WebSocketGateway(8180, { namespace: 'core' })
 export class CoreGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
@@ -58,9 +64,14 @@ export class CoreGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 
         await this.lobbyService.joinLobby(user, lobby.id);
         await client.join(body.lobbyId);
-        // TODO: 현재 클라이언트 이름 없이 socket 정보만 관리하고 있음. 나중에 클라이언트 정보 정해지면, 클라이언트 정보로 변경 필요
-        client.broadcast.to(lobby.id).emit('join-lobby', client);
-        return lobby.users;
+        client
+            .to(lobby.id)
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            .emit('join-lobby', { userName: body.userName } as JoinLobbyReEmitRequest);
+
+        return lobby.users.map((user) => {
+            return { userName: user.name };
+        }) as JoinLobbyResponse;
     }
 
     @SubscribeMessage('leave-lobby')

--- a/backend/src/core/lobby.service.ts
+++ b/backend/src/core/lobby.service.ts
@@ -19,7 +19,7 @@ export class LobbyService {
         this.store[lobbyId] = {
             id: lobbyId,
             host: user,
-            users: [user],
+            users: [],
         };
         return lobbyId;
     }

--- a/backend/src/core/user.dto.ts
+++ b/backend/src/core/user.dto.ts
@@ -12,3 +12,9 @@ export class JoinLobbyRequest {
     @IsNotEmpty()
     public lobbyId: string;
 }
+
+export type JoinLobbyResponse = Array<{ userName: string }>;
+
+export interface JoinLobbyReEmitRequest {
+    userName: string;
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,6 +5,6 @@ import { ValidationPipe } from '@nestjs/common';
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
     app.useGlobalPipes(new ValidationPipe());
-    await app.listen(3000);
+    await app.listen(8080);
 }
 bootstrap();

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,8 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.3",
         "react-scripts": "5.0.1",
+        "recoil": "^0.7.6",
+        "socket.io-client": "^4.5.3",
         "styled-components": "^5.3.6",
         "typescript": "^4.8.4",
         "web-vitals": "^2.1.4"
@@ -3019,6 +3021,11 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -6170,6 +6177,46 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.3.tgz",
+      "integrity": "sha512-aXPtgF1JS3RuuKcpSrBtimSjYvrbhKW9froICH4s0F3XQWLxsKNxqzG39nnvQZQnva4CMvUK63T7shevxRyYHw==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.2.3",
+        "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
+      "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.10.0",
       "license": "MIT",
@@ -7899,6 +7946,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -13291,6 +13343,25 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recoil": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.6.tgz",
+      "integrity": "sha512-hsBEw7jFdpBCY/tu2GweiyaqHKxVj6EqF2/SfrglbKvJHhpN57SANWvPW+gE90i3Awi+A5gssOd3u+vWlT+g7g==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
       "license": "MIT",
@@ -13964,6 +14035,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.3.tgz",
+      "integrity": "sha512-I/hqDYpQ6JKwtJOf5ikM+Qz+YujZPMEl6qBLhxiP0nX+TfXKhW4KZZG8lamrD6Y5ngjmYHreESVasVCgi5Kl3A==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.2.3",
+        "socket.io-parser": "~4.2.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
+      "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/sockjs": {
@@ -15818,6 +15915,14 @@
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,8 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3",
     "react-scripts": "5.0.1",
+    "recoil": "^0.7.6",
+    "socket.io-client": "^4.5.3",
     "styled-components": "^5.3.6",
     "typescript": "^4.8.4",
     "web-vitals": "^2.1.4"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import { Route, Routes } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 import Main from '@pages/Main';
 import Lobby from '@pages/Lobby';
 import Game from '@pages/Game';
 
 function App() {
     return (
-        <Routes>
-            <Route path='/' element={<Main />} />
-            <Route path='/lobby' element={<Lobby />} />
-            <Route path='/game' element={<Game />} />
-        </Routes>
+        <RecoilRoot>
+            <Routes>
+                <Route path='/' element={<Main />} />
+                <Route path='/lobby' element={<Lobby />} />
+                <Route path='/game' element={<Game />} />
+            </Routes>
+        </RecoilRoot>
     );
 }
 

--- a/frontend/src/atoms/game.ts
+++ b/frontend/src/atoms/game.ts
@@ -1,0 +1,9 @@
+import { atom } from 'recoil';
+
+/**
+ * 로비(게임)에 접속한 유저 리스트
+ */
+export const userListState = atom<string[]>({
+    key: 'userListState',
+    default: [],
+});

--- a/frontend/src/atoms/user.ts
+++ b/frontend/src/atoms/user.ts
@@ -1,9 +1,17 @@
 import { atom } from 'recoil';
 
-export const userState = atom({
+interface userStateType {
+    name: string;
+    isHost: boolean | null;
+}
+
+/**
+ * 사용자 정보 (name, host 여부)
+ */
+export const userState = atom<userStateType>({
     key: 'userState',
     default: {
         name: 'test',
-        isHost: true,
+        isHost: null,
     },
 });

--- a/frontend/src/atoms/user.ts
+++ b/frontend/src/atoms/user.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const userState = atom({
+    key: 'name',
+    default: '',
+});

--- a/frontend/src/atoms/user.ts
+++ b/frontend/src/atoms/user.ts
@@ -1,6 +1,9 @@
 import { atom } from 'recoil';
 
 export const userState = atom({
-    key: 'name',
-    default: '',
+    key: 'userState',
+    default: {
+        name: 'test',
+        isHost: true,
+    },
 });

--- a/frontend/src/components/InfoCard.tsx
+++ b/frontend/src/components/InfoCard.tsx
@@ -4,9 +4,27 @@ import Card from '@components/Card';
 import PrimaryButton from '@components/PrimaryButton';
 import Carousel from '@components/Carousel';
 import useMovePage from '@hooks/useMovePage';
+import { userState } from '../atoms/user';
+import { useRecoilValue } from 'recoil';
+import { networkServiceInstance as NetworkService } from '../services/socketService';
 
 function InfoCard() {
+    const userName = useRecoilValue(userState);
     const [setPage] = useMovePage();
+    // const [host, setHost] = useState<boolean>(false);
+    const host = false;
+    const params = new URLSearchParams(location.search);
+
+    const onClickEnterBtn = () => {
+        let lobbyId = params.get('id') ?? '';
+        if (host) {
+            NetworkService.emit('create-lobby', { name: userName }, (res: string) => {
+                console.log(res);
+                lobbyId = res;
+            });
+        }
+        setPage(`/lobby?id=${lobbyId}`);
+    };
 
     return (
         <Card>
@@ -15,8 +33,12 @@ function InfoCard() {
                 <InfoDiv>
                     <Carousel />
                 </InfoDiv>
-                <ButtonWrapper onClick={() => setPage('/lobby')}>
-                    <PrimaryButton topText='ENTER ROOM' bottomText='입장하기' />
+                <ButtonWrapper onClick={onClickEnterBtn}>
+                    {host ? (
+                        <PrimaryButton topText='NEW ROOM' bottomText='방만들기' />
+                    ) : (
+                        <PrimaryButton topText='ENTER ROOM' bottomText='입장하기' />
+                    )}
                 </ButtonWrapper>
             </CardInner>
         </Card>

--- a/frontend/src/components/InfoCard.tsx
+++ b/frontend/src/components/InfoCard.tsx
@@ -9,21 +9,18 @@ import { useRecoilValue } from 'recoil';
 import { networkServiceInstance as NetworkService } from '../services/socketService';
 
 function InfoCard() {
-    const userName = useRecoilValue(userState);
+    const user = useRecoilValue(userState);
     const [setPage] = useMovePage();
-    // const [host, setHost] = useState<boolean>(false);
-    const host = false;
     const params = new URLSearchParams(location.search);
 
     const onClickEnterBtn = () => {
         let lobbyId = params.get('id') ?? '';
-        if (host) {
-            NetworkService.emit('create-lobby', { name: userName }, (res: string) => {
-                console.log(res);
+        if (user.isHost) {
+            NetworkService.emit('create-lobby', { userName: user.name }, (res: string) => {
                 lobbyId = res;
+                setPage(`/lobby?id=${lobbyId}`);
             });
         }
-        setPage(`/lobby?id=${lobbyId}`);
     };
 
     return (
@@ -34,7 +31,7 @@ function InfoCard() {
                     <Carousel />
                 </InfoDiv>
                 <ButtonWrapper onClick={onClickEnterBtn}>
-                    {host ? (
+                    {user.isHost ? (
                         <PrimaryButton topText='NEW ROOM' bottomText='방만들기' />
                     ) : (
                         <PrimaryButton topText='ENTER ROOM' bottomText='입장하기' />

--- a/frontend/src/components/InfoCard.tsx
+++ b/frontend/src/components/InfoCard.tsx
@@ -1,27 +1,33 @@
-import React from 'react';
+import { useEffect } from 'react';
 import styled from 'styled-components';
 import Card from '@components/Card';
 import PrimaryButton from '@components/PrimaryButton';
 import Carousel from '@components/Carousel';
 import useMovePage from '@hooks/useMovePage';
-import { userState } from '../atoms/user';
-import { useRecoilValue } from 'recoil';
+import { userState } from '@atoms/user';
+import { useRecoilState } from 'recoil';
 import { networkServiceInstance as NetworkService } from '../services/socketService';
+import { getParam } from '@utils/common';
 
 function InfoCard() {
-    const user = useRecoilValue(userState);
+    const [user, setUser] = useRecoilState(userState);
     const [setPage] = useMovePage();
-    const params = new URLSearchParams(location.search);
+    const lobbyId = getParam('id');
 
     const onClickEnterBtn = () => {
-        let lobbyId = params.get('id') ?? '';
         if (user.isHost) {
             NetworkService.emit('create-lobby', { userName: user.name }, (res: string) => {
-                lobbyId = res;
-                setPage(`/lobby?id=${lobbyId}`);
+                setPage(`/lobby?id=${res}`);
             });
+        } else {
+            setPage(`/lobby?id=${lobbyId}`);
         }
     };
+
+    useEffect(() => {
+        if (user.isHost) return;
+        setUser({ ...user, isHost: lobbyId === '' });
+    }, []);
 
     return (
         <Card>
@@ -73,7 +79,7 @@ const InfoDiv = styled.div`
     letter-spacing: -0.05em;
     color: ${({ theme }) => theme.color.white};
     display: flex;
-    justify-contents: center;
+    justify-content: center;
 
     h3 {
         width: 403px;

--- a/frontend/src/components/InviteButton.tsx
+++ b/frontend/src/components/InviteButton.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
+import { getParam } from '@utils/common';
 
 function InviteButton() {
-    const params = new URLSearchParams(location.search);
-
     const onClickInviteBtn = () => {
-        console.log(params.get('id'));
+        console.log(getParam('id'));
     };
     return (
         <InviteBtn onClick={onClickInviteBtn}>

--- a/frontend/src/components/InviteButton.tsx
+++ b/frontend/src/components/InviteButton.tsx
@@ -2,8 +2,13 @@ import React from 'react';
 import styled from 'styled-components';
 
 function InviteButton() {
+    const params = new URLSearchParams(location.search);
+
+    const onClickInviteBtn = () => {
+        console.log(params.get('id'));
+    };
     return (
-        <InviteBtn>
+        <InviteBtn onClick={onClickInviteBtn}>
             INVITE<h3>초대하기</h3>
         </InviteBtn>
     );

--- a/frontend/src/components/UserCard.tsx
+++ b/frontend/src/components/UserCard.tsx
@@ -4,15 +4,15 @@ import Card from '@components/Card';
 import CameraButton from '@components/CameraButton';
 import MicButton from '@components/MicButton';
 import { userState } from '../atoms/user';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 
 function UserCard() {
-    const setUserState = useSetRecoilState(userState);
+    const [user, setUserState] = useRecoilState(userState);
     const [micState, setMicState] = useState<boolean>(true);
     const [cameraState, setCameraState] = useState<boolean>(true);
 
     const setUserNickname = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setUserState(e.target.value);
+        setUserState({ ...user, name: e.target.value });
     };
 
     return (

--- a/frontend/src/components/UserCard.tsx
+++ b/frontend/src/components/UserCard.tsx
@@ -1,15 +1,13 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import Card from '@components/Card';
 import CameraButton from '@components/CameraButton';
 import MicButton from '@components/MicButton';
-import { userState } from '../atoms/user';
+import { userState } from '@atoms/user';
 import { useRecoilState } from 'recoil';
 
 function UserCard() {
     const [user, setUserState] = useRecoilState(userState);
-    const [micState, setMicState] = useState<boolean>(true);
-    const [cameraState, setCameraState] = useState<boolean>(true);
 
     const setUserNickname = (e: React.ChangeEvent<HTMLInputElement>) => {
         setUserState({ ...user, name: e.target.value });
@@ -21,13 +19,12 @@ function UserCard() {
                 <UserVideo></UserVideo>
                 <UserName>
                     <span>&#123;</span>
-                    <span>
-                        <NameInput
-                            type='text'
-                            defaultValue={'젤루조아13579'}
-                            onChange={setUserNickname}
-                        />
-                    </span>
+                    <NameInput
+                        type='text'
+                        placeholder={user.name}
+                        onChange={setUserNickname}
+                        maxLength={7}
+                    />
                     <span>&#125;</span>
                 </UserName>
                 <ButtonWrapper>
@@ -57,29 +54,13 @@ const UserVideo = styled.div`
 
 const UserName = styled.div`
     text-align: center;
-
     span {
-        &:not(:nth-of-type(2)) {
-            // 중괄호
-            color: ${({ theme }) => theme.color.whiteT2};
-            font-family: 'Sniglet', cursive;
-            font-weight: 800;
-            font-size: 2rem;
-            padding: 4px;
-        }
-
-        :nth-child(2) {
-            // 유저 이름
-            margin: 0 2px;
-            transform: translateY(-2px);
-            font-style: normal;
-            font-weight: 600;
-            font-size: ${({ theme }) => theme.typo.h3};
-            line-height: 160%;
-            letter-spacing: -0.05em;
-            color: ${({ theme }) => theme.color.yellow};
-            -webkit-text-stroke: 1px ${({ theme }) => theme.color.blackT1};
-        }
+        // 중괄호
+        color: ${({ theme }) => theme.color.whiteT2};
+        font-family: 'Sniglet', cursive;
+        font-weight: 800;
+        font-size: 2rem;
+        padding: 4px;
     }
 `;
 
@@ -94,5 +75,15 @@ const ButtonWrapper = styled.div`
 
 const NameInput = styled.input`
     width: 201px;
-    // input 최대값 설정하기
+    background: transparent;
+    text-align: center;
+    margin: 0 2px;
+    transform: translateY(-2px);
+    font-style: normal;
+    font-weight: 600;
+    font-size: ${({ theme }) => theme.typo.h3};
+    line-height: 160%;
+    letter-spacing: -0.05em;
+    color: ${({ theme }) => theme.color.yellow};
+    -webkit-text-stroke: 1px ${({ theme }) => theme.color.blackT1};
 `;

--- a/frontend/src/components/UserCard.tsx
+++ b/frontend/src/components/UserCard.tsx
@@ -1,13 +1,19 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import Card from '@components/Card';
-import VideoCallUser from '@components/VideoCallUser';
 import CameraButton from '@components/CameraButton';
 import MicButton from '@components/MicButton';
+import { userState } from '../atoms/user';
+import { useSetRecoilState } from 'recoil';
 
 function UserCard() {
+    const setUserState = useSetRecoilState(userState);
     const [micState, setMicState] = useState<boolean>(true);
     const [cameraState, setCameraState] = useState<boolean>(true);
+
+    const setUserNickname = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setUserState(e.target.value);
+    };
 
     return (
         <Card>
@@ -15,7 +21,13 @@ function UserCard() {
                 <UserVideo></UserVideo>
                 <UserName>
                     <span>&#123;</span>
-                    <span>젤루조아13579</span>
+                    <span>
+                        <NameInput
+                            type='text'
+                            defaultValue={'젤루조아13579'}
+                            onChange={setUserNickname}
+                        />
+                    </span>
                     <span>&#125;</span>
                 </UserName>
                 <ButtonWrapper>
@@ -78,4 +90,9 @@ const ButtonWrapper = styled.div`
     gap: 20px;
     margin-bottom: 0;
     margin-top: 77px;
+`;
+
+const NameInput = styled.input`
+    width: 201px;
+    // input 최대값 설정하기
 `;

--- a/frontend/src/components/UserList.tsx
+++ b/frontend/src/components/UserList.tsx
@@ -4,35 +4,11 @@ import Card from '@components/Card';
 import InviteButton from '@components/InviteButton';
 import EmptyVideoCall from '@components/EmptyVideoCall';
 import VideoCallUser from '@components/VideoCallUser';
-import { networkServiceInstance as NetworkService } from '../services/socketService';
 import { useRecoilValue } from 'recoil';
-import { userState } from '../atoms/user';
+import { userListState } from '@atoms/game';
 
 function UserList() {
-    const [userList, setUserList] = useState<string[]>([]);
-    const user = useRecoilValue(userState);
-    const params = new URLSearchParams(location.search);
-
-    useEffect(() => {
-        const lobbyId = params.get('id') ?? '';
-        NetworkService.emit(
-            'join-lobby',
-            { userName: user.name, lobbyId },
-            (res: Array<{ userName: string }>) => {
-                const data = res.map((user) => user.userName);
-                setUserList(data);
-            },
-        );
-    }, []);
-
-    useEffect(() => {
-        NetworkService.on('join-lobby', (user: { userName: string }) => {
-            setUserList([...userList, user.userName]);
-        });
-        return () => {
-            NetworkService.off('join-lobby');
-        };
-    }, [userList]);
+    const userList = useRecoilValue(userListState);
 
     return (
         <Card>

--- a/frontend/src/components/UserList.tsx
+++ b/frontend/src/components/UserList.tsx
@@ -1,12 +1,26 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import Card from '@components/Card';
 import InviteButton from '@components/InviteButton';
 import EmptyVideoCall from '@components/EmptyVideoCall';
 import VideoCallUser from '@components/VideoCallUser';
+import { networkServiceInstance as NetworkService } from '../services/socketService';
 
 function UserList() {
-    const userList: string[] = ['젤로조아13579', '젤로조아13578', '젤로조아13577'];
+    const [userList, setUserList] = useState<string[]>([]);
+    const params = new URLSearchParams(location.search);
+
+    useEffect(() => {
+        NetworkService.emit('join-lobby', params.get('id') ?? '', (res: any[]) => {
+            console.log(res);
+            setUserList(res);
+        });
+        NetworkService.on('join-lobby', (user) => {
+            console.log(user);
+            setUserList([...userList, user]);
+        });
+    }, []);
+
     return (
         <Card>
             <CardInner>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -9,12 +9,12 @@ import { GlobalStyle } from '@styles/GlobalStyle';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
-    <React.StrictMode>
-        <BrowserRouter>
-            <ThemeProvider theme={ZelloTheme}>
-                <App />
-                <GlobalStyle />
-            </ThemeProvider>
-        </BrowserRouter>
-    </React.StrictMode>,
+    // <React.StrictMode>
+    <BrowserRouter>
+        <ThemeProvider theme={ZelloTheme}>
+            <App />
+            <GlobalStyle />
+        </ThemeProvider>
+    </BrowserRouter>,
+    // </React.StrictMode>,
 );

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -6,7 +6,7 @@ import GameUsers from '@components/GameUsers';
 import PrimaryButton from '@components/PrimaryButton';
 import MicButton from '@components/MicButton';
 import CameraButton from '@components/CameraButton';
-import Logo from '@assets/logo-s.png';
+import Logo from '@assets/logo-s.svg';
 
 function Game() {
     const [onDraw, setOnDraw] = useState(true);

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -6,9 +6,12 @@ import InfoCard from '@components/InfoCard';
 import GuestEntranceMessage from '@components/GuestMessageBox';
 import MadeByText from '@components/MadeByText';
 import useMovePage from '@hooks/useMovePage';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@atoms/user';
 
 function Main() {
     const [setPage] = useMovePage();
+    const user = useRecoilValue(userState);
 
     return (
         <MainContainer>
@@ -17,7 +20,7 @@ function Main() {
                 <UserCard />
                 <InfoCard />
             </CardContainer>
-            <GuestEntranceMessage />
+            {!user.isHost && <GuestEntranceMessage />}
             <LogoWrapper>
                 <MadeByText />
             </LogoWrapper>

--- a/frontend/src/services/socketService.ts
+++ b/frontend/src/services/socketService.ts
@@ -1,0 +1,39 @@
+import { io, Socket } from 'socket.io-client';
+
+export class SocketService {
+    private static instance: SocketService;
+    private readonly socket: Socket;
+    public socketId = '';
+
+    private constructor() {
+        this.socket = io('ws://localhost:8180/core', {
+            transports: ['websocket'],
+        });
+        this.socket.connect();
+        // TODO: 타이밍 이슈 여부 파악 및 해결
+        this.socket.on('connect', () => {
+            this.socketId = this.socket.id;
+        });
+    }
+
+    public static getInstance() {
+        if (this.instance === undefined) {
+            this.instance = new SocketService();
+        }
+        return this.instance;
+    }
+
+    public on(event: string, callback: (...args: any[]) => void) {
+        this.socket.on(event, callback);
+    }
+
+    public off(event: string) {
+        this.socket.off(event);
+    }
+
+    public emit(event: string, ...args: any[]) {
+        this.socket.emit(event, ...args);
+    }
+}
+
+export const networkServiceInstance = SocketService.getInstance();

--- a/frontend/src/utils/common.ts
+++ b/frontend/src/utils/common.ts
@@ -1,0 +1,4 @@
+export function getParam(key: string): string {
+    const params = new URLSearchParams(location.search);
+    return params.get(key) ?? '';
+}

--- a/frontend/tsconfig.paths.json
+++ b/frontend/tsconfig.paths.json
@@ -6,7 +6,9 @@
             "@assets/*": ["./assets/*"],
             "@pages/*": ["./pages/*"],
             "@styles/*": ["./styles/*"],
-            "@hooks/*": ["./hooks/*"]
+            "@hooks/*": ["./hooks/*"],
+            "@atoms/*": ["./atoms/*"],
+            "@utils/*": ["./utils/*"]
         }
     }
 }


### PR DESCRIPTION
## 상세내용
* 메인 페이지에서 로비 페이지까지 플로우가 작동하도록 로직을 구현하였어요.

* 로비에 참가한 유저 리스트 recoil state로 변경,
* 유저리스트 관련 로직들 lobby 페이지로 옮김,
* 유저 호스트 여부 판단 추가
* userList를 사용하는 소켓 로직을 userList depency를 가진 useEffect 에서 처리하도록 함. (이렇게 하지 않으면 on 내부 콜백 함수의 컨텍스트 환경에서  과거의 userList를 바라봄


## 추가 구현 필요 사항
* 로비에서 유저가 나갈 때 처리
* 최대 8명까지 로비에서 받도록 처리
* 로비가 존재하지 않을 때 처리
* 로비에 아무도 없을 경우 처리
* 존재하지 않는 로비에 접근하였을 때 처리