### PR TITLE
[feat] 로비 벗어나기 기능, 유저 이름 변경 기능 구현

### DIFF
--- a/backend/src/core/core.gateway.ts
+++ b/backend/src/core/core.gateway.ts
@@ -36,6 +36,11 @@ export class CoreGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
         console.log('afterInit');
     }
 
+    @SubscribeMessage('update-user-name')
+    async handleCreateUser(@ConnectedSocket() client: Socket, @MessageBody() userName: string) {
+        return this.userService.updateUser(client.id, { name: userName });
+    }
+
     @SubscribeMessage('create-lobby')
     // TODO: return type WsResponse 로 바꿔야함. + 학습 필요.
     async handleCreateLobby(@ConnectedSocket() client: Socket) {

--- a/backend/src/core/core.gateway.ts
+++ b/backend/src/core/core.gateway.ts
@@ -28,12 +28,13 @@ export class CoreGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
         private readonly userService: UserService,
     ) {}
 
-    handleDisconnect(client: any) {
-        console.log('disconnect');
+    handleConnection(client: any) {
+        this.userService.createUser(client.id, 'noname');
     }
 
-    handleConnection(client: any, ...args: any[]) {
-        console.log('connect');
+    async handleDisconnect(@ConnectedSocket() client: Socket) {
+        await this.handleLeaveLobby(client);
+        this.userService.deleteUser(client.id);
     }
 
     afterInit(server: any) {
@@ -47,7 +48,7 @@ export class CoreGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
         @MessageBody() body: CreateLobbyRequest,
     ) {
         // TODO: socket connection 라이프 사이클에 user 생성, 삭제 로직 할당
-        const user = this.userService.createUser(client.id, body.userName);
+        const user = this.userService.getUser(client.id);
         const lobbyId = this.lobbyService.createLobby(user);
         await client.join(lobbyId);
         return lobbyId;
@@ -60,7 +61,7 @@ export class CoreGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     ) {
         const lobby = this.lobbyService.getLobby(body.lobbyId);
         // TODO: socket connection 라이프 사이클에 user 생성, 삭제 로직 할당
-        const user = this.userService.createUser(client.id, body.userName);
+        const user = this.userService.getUser(client.id);
 
         await this.lobbyService.joinLobby(user, lobby.id);
         await client.join(body.lobbyId);

--- a/backend/src/core/lobby.service.ts
+++ b/backend/src/core/lobby.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { User } from './user.model';
+import { UserService } from './user.service';
 
 export interface LobbyStore {
     [key: string]: Lobby;
@@ -12,6 +13,8 @@ export interface Lobby {
 }
 @Injectable()
 export class LobbyService {
+    constructor(private readonly userService: UserService) {}
+
     store: LobbyStore = {};
 
     createLobby(user: User): string {
@@ -27,12 +30,14 @@ export class LobbyService {
     async joinLobby(user: User, lobbyId: string) {
         const lobby = this.getLobby(lobbyId);
         lobby.users.push(user);
+        this.userService.updateUser(user.socketId, { lobbyId });
         return lobby.users;
     }
 
-    async leaveLobby(user: User, lobbyId: string) {
+    leaveLobby(user: User, lobbyId: string) {
         const lobby = this.getLobby(lobbyId);
         lobby.users = lobby.users.filter((iUser) => iUser.socketId !== user.socketId);
+        this.userService.updateUser(user.socketId, { lobbyId: undefined });
         return lobby.users;
     }
 

--- a/backend/src/core/user.dto.ts
+++ b/backend/src/core/user.dto.ts
@@ -1,14 +1,6 @@
 import { IsNotEmpty } from 'class-validator';
 
-export class CreateLobbyRequest {
-    @IsNotEmpty()
-    public userName: string;
-}
-
 export class JoinLobbyRequest {
-    @IsNotEmpty()
-    public userName: string;
-
     @IsNotEmpty()
     public lobbyId: string;
 }

--- a/backend/src/core/user.model.ts
+++ b/backend/src/core/user.model.ts
@@ -4,8 +4,9 @@ export class User {
     @IsNotEmpty()
     socketId: string;
 
-    @IsNotEmpty()
     name: string;
+
+    lobbyId: string | undefined;
 
     constructor(socketId: string, name: string) {
         this.socketId = socketId;

--- a/backend/src/core/user.service.ts
+++ b/backend/src/core/user.service.ts
@@ -29,4 +29,9 @@ export class UserService {
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete this.store[socketId];
     }
+
+    updateUser(socketId: string, param: Partial<User>) {
+        this.store[socketId] = { ...this.store[socketId], ...param };
+        return this.store[socketId];
+    }
 }

--- a/frontend/src/atoms/user.ts
+++ b/frontend/src/atoms/user.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 
-interface userStateType {
+export interface userStateType {
     name: string;
     isHost: boolean | null;
 }

--- a/frontend/src/components/InfoCard.tsx
+++ b/frontend/src/components/InfoCard.tsx
@@ -3,26 +3,13 @@ import styled from 'styled-components';
 import Card from '@components/Card';
 import PrimaryButton from '@components/PrimaryButton';
 import Carousel from '@components/Carousel';
-import useMovePage from '@hooks/useMovePage';
 import { userState } from '@atoms/user';
 import { useRecoilState } from 'recoil';
-import { networkServiceInstance as NetworkService } from '../services/socketService';
 import { getParam } from '@utils/common';
 
-function InfoCard() {
+function InfoCard({ onHandleEnterLobby }: { onHandleEnterLobby: () => void }) {
     const [user, setUser] = useRecoilState(userState);
-    const [setPage] = useMovePage();
     const lobbyId = getParam('id');
-
-    const onClickEnterBtn = () => {
-        if (user.isHost) {
-            NetworkService.emit('create-lobby', { userName: user.name }, (res: string) => {
-                setPage(`/lobby?id=${res}`);
-            });
-        } else {
-            setPage(`/lobby?id=${lobbyId}`);
-        }
-    };
 
     useEffect(() => {
         if (user.isHost) return;
@@ -36,7 +23,7 @@ function InfoCard() {
                 <InfoDiv>
                     <Carousel />
                 </InfoDiv>
-                <ButtonWrapper onClick={onClickEnterBtn}>
+                <ButtonWrapper onClick={onHandleEnterLobby}>
                     {user.isHost ? (
                         <PrimaryButton topText='NEW ROOM' bottomText='방만들기' />
                     ) : (

--- a/frontend/src/components/UserCard.tsx
+++ b/frontend/src/components/UserCard.tsx
@@ -5,12 +5,15 @@ import CameraButton from '@components/CameraButton';
 import MicButton from '@components/MicButton';
 import { userState } from '@atoms/user';
 import { useRecoilState } from 'recoil';
+import { networkServiceInstance as NetworkService } from '../services/socketService';
 
 function UserCard() {
     const [user, setUserState] = useRecoilState(userState);
 
     const setUserNickname = (e: React.ChangeEvent<HTMLInputElement>) => {
+        console.log(e.target.value);
         setUserState({ ...user, name: e.target.value });
+        NetworkService.emit('update-user-name', user.name);
     };
 
     return (

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -27,6 +27,13 @@ function Lobby() {
                 setUserList(data);
             },
         );
+        NetworkService.on('leave-lobby', (users: Array<{ userName: string }>) => {
+            setUserList(users.map((user) => user.userName));
+        });
+
+        return () => {
+            NetworkService.off('leave-lobby');
+        };
     }, []);
 
     useEffect(() => {

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -8,17 +8,30 @@ import MadeByText from '@components/MadeByText';
 import useMovePage from '@hooks/useMovePage';
 import { useRecoilValue } from 'recoil';
 import { userState } from '@atoms/user';
+import { networkServiceInstance as NetworkService } from '../services/socketService';
+import { getParam } from '@utils/common';
 
 function Main() {
     const [setPage] = useMovePage();
     const user = useRecoilValue(userState);
+    const lobbyId = getParam('id');
+
+    const onClickEnterBtn = () => {
+        if (user.isHost) {
+            NetworkService.emit('create-lobby', { userName: user.name }, (res: string) => {
+                setPage(`/lobby?id=${res}`);
+            });
+        } else {
+            setPage(`/lobby?id=${lobbyId}`);
+        }
+    };
 
     return (
         <MainContainer>
             <MainLogo style={{ cursor: 'pointer' }} onClick={() => setPage('/')} />
             <CardContainer>
                 <UserCard />
-                <InfoCard />
+                <InfoCard onHandleEnterLobby={onClickEnterBtn} />
             </CardContainer>
             {!user.isHost && <GuestEntranceMessage />}
             <LogoWrapper>

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import UserCard from '@components/UserCard';
 import { ReactComponent as MainLogo } from '@assets/logo-l.svg';
@@ -7,14 +7,18 @@ import GuestEntranceMessage from '@components/GuestMessageBox';
 import MadeByText from '@components/MadeByText';
 import useMovePage from '@hooks/useMovePage';
 import { useRecoilValue } from 'recoil';
-import { userState } from '@atoms/user';
+import { userState, userStateType } from '@atoms/user';
 import { networkServiceInstance as NetworkService } from '../services/socketService';
 import { getParam } from '@utils/common';
 
 function Main() {
     const [setPage] = useMovePage();
-    const user = useRecoilValue(userState);
+    const user = useRecoilValue<userStateType>(userState);
     const lobbyId = getParam('id');
+
+    useEffect(() => {
+        NetworkService.emit('update-user-name', user.name);
+    }, []);
 
     const onClickEnterBtn = () => {
         if (user.isHost) {


### PR DESCRIPTION
* 로비 벗어나기 기능을 구현했어요
* 유저 이름 변경 기능을 구현했어요.
* 백엔드에서 관리하는 UserService의 유저 생성/삭제 라이프사이클이 socket connection 기준으로 이루어지도록 구현했어요. 
   * 이전에는 로비에 진입 시 유저 데이터를 생성해서 관리하였는데, 소켓에 연결(서비스에 연결) 되자마자 유저가 되는 것이 플로우상 자연스러워 보임.
   * 소켓이 연결될 때 User 생성, 소켓이 해제될 때 User 삭제.
* 몇가지 백엔드 소켓 API 의 payload들이 수정되었어요.