### PR TITLE
[feat] start-round 관련 코드 리팩터링

### DIFF
--- a/frontend/src/components/GameModeList.tsx
+++ b/frontend/src/components/GameModeList.tsx
@@ -1,17 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import { ReactComponent as GirlWithPencilChar } from '@assets/girl-with-pencil 1.svg';
+import { emitStartGame, onStartGame } from '@game/NetworkServiceUtils';
+import { useSetRecoilState, useRecoilValue } from 'recoil';
+import { userState, userStateType } from '@atoms/user';
+import { roundInfoState, roundInfoType } from '@atoms/game';
+import useMovePage from '@hooks/useMovePage';
+import PrimaryButton from '@components/PrimaryButton';
 import Card from '@components/Card';
 import GameModeItem from '@components/GameModeItem';
-import { ReactComponent as GirlWithPencilChar } from '@assets/girl-with-pencil 1.svg';
-import PrimaryButton from '@components/PrimaryButton';
-import { emitStartGame, onStartGame } from '@game/NetworkServiceUtils';
-import useMovePage from '@hooks/useMovePage';
-import { useRecoilValue } from 'recoil';
-import { userState, userStateType } from '@atoms/user';
 
 function GameModeList({ lobbyId }: { lobbyId: string }) {
     const user = useRecoilValue<userStateType>(userState);
+    const setRoundInfo = useSetRecoilState<roundInfoType>(roundInfoState);
     const [setPage] = useMovePage();
+
     const modes = [
         {
             title: 'RANDOM KEYWORD',
@@ -27,7 +30,7 @@ function GameModeList({ lobbyId }: { lobbyId: string }) {
     };
 
     useEffect(() => {
-        onStartGame(setPage);
+        onStartGame(setPage, setRoundInfo);
     }, []);
 
     return (

--- a/frontend/src/components/GameModeList.tsx
+++ b/frontend/src/components/GameModeList.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { ReactComponent as GirlWithPencilChar } from '@assets/girl-with-pencil 1.svg';
-import { emitStartGame, onStartGame } from '@game/NetworkServiceUtils';
+import { onStartGame } from '@game/NetworkServiceUtils';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { userState, userStateType } from '@atoms/user';
 import { roundInfoState, roundInfoType } from '@atoms/game';
 import useMovePage from '@hooks/useMovePage';
-import PrimaryButton from '@components/PrimaryButton';
 import Card from '@components/Card';
 import GameModeItem from '@components/GameModeItem';
+import GameStartButton from '@components/GameStartButton';
 
 function GameModeList({ lobbyId }: { lobbyId: string }) {
     const user = useRecoilValue<userStateType>(userState);
@@ -23,12 +23,6 @@ function GameModeList({ lobbyId }: { lobbyId: string }) {
         },
     ];
 
-    const onClickStartBtn = () => {
-        // 게임시작 이벤트 발생
-        emitStartGame(lobbyId);
-        console.log('게임시작');
-    };
-
     useEffect(() => {
         onStartGame(setPage, setRoundInfo);
     }, []);
@@ -40,9 +34,7 @@ function GameModeList({ lobbyId }: { lobbyId: string }) {
                     <GameModeItem mode={mode} key={mode.title} isSelected={idx === 0} />
                 ))}
                 {user.isHost ? (
-                    <ButtonWrapper onClick={onClickStartBtn}>
-                        <PrimaryButton topText='START GAME' bottomText='시작하기' />
-                    </ButtonWrapper>
+                    <GameStartButton lobbyId={lobbyId} />
                 ) : (
                     <TextWrapper>
                         <span>*</span> 게임 시작을 기다리고 있어요... <span>*</span>
@@ -60,10 +52,6 @@ const CardInner = styled.div`
     height: 616px;
     display: flex;
     flex-direction: column;
-`;
-
-const ButtonWrapper = styled.div`
-    margin: auto 0 0 auto;
 `;
 
 const TextWrapper = styled.div`

--- a/frontend/src/components/GameStartButton.tsx
+++ b/frontend/src/components/GameStartButton.tsx
@@ -1,0 +1,21 @@
+import PrimaryButton from '@components/PrimaryButton';
+import React from 'react';
+import styled from 'styled-components';
+import { emitStartGame } from '@game/NetworkServiceUtils';
+
+export default function GameStartButton({ lobbyId }: { lobbyId: string }) {
+    const onClickStartBtn = () => {
+        // 게임시작 이벤트 발생
+        emitStartGame(lobbyId);
+    };
+
+    return (
+        <ButtonWrapper onClick={onClickStartBtn}>
+            <PrimaryButton topText='START GAME' bottomText='시작하기' />
+        </ButtonWrapper>
+    );
+}
+
+const ButtonWrapper = styled.div`
+    margin: auto 0 0 auto;
+`;

--- a/frontend/src/game/NetworkServiceUtils.ts
+++ b/frontend/src/game/NetworkServiceUtils.ts
@@ -1,14 +1,18 @@
 import { networkServiceInstance as NetworkService } from '@services/socketService';
 import { roundInfoType } from '@atoms/game';
+import { SetterOrUpdater } from 'recoil';
 
 export const emitStartGame = (lobbyId: string) => {
     NetworkService.emit('start-game', lobbyId);
 };
 
-export const onStartGame = (setPage: (url: string) => void) => {
+export const onStartGame = (
+    setPage: (url: string) => void,
+    setRoundInfo: SetterOrUpdater<roundInfoType>,
+) => {
     NetworkService.on('start-game', (payload: any) => {
-        console.log('onStartGame payload', payload);
         emitStartRound(payload.lobbyId);
+        getRoundInfo(setRoundInfo);
         setPage('/game');
     });
 };
@@ -17,10 +21,8 @@ export const emitStartRound = (lobbyId: string) => {
     NetworkService.emit('start-round', lobbyId);
 };
 
-export const getRoundInfo = async () => {
-    return await new Promise<roundInfoType>((resolve) => {
-        NetworkService.on('start-round', (userRound: roundInfoType) => {
-            resolve(userRound);
-        });
+export const getRoundInfo = (setRoundInfo: SetterOrUpdater<roundInfoType>) => {
+    NetworkService.on('start-round', (userRound: roundInfoType) => {
+        setRoundInfo(userRound);
     });
 };

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -1,9 +1,8 @@
 import styled from 'styled-components';
 import { useEffect, useState } from 'react';
 import { Center } from '@styles/styled';
-import { useRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { roundInfoState, roundInfoType } from '@atoms/game';
-import { getRoundInfo } from '@game/NetworkServiceUtils';
 import SketchbookCard from '@components/SketchbookCard';
 import GameUsers from '@components/GameUsers';
 import PrimaryButton from '@components/PrimaryButton';
@@ -14,20 +13,15 @@ import useMovePage from '@hooks/useMovePage';
 
 function Game() {
     const [setPage] = useMovePage();
-    const [roundInfo, setRoundInfo] = useRecoilState<roundInfoType>(roundInfoState);
+    const roundInfo = useRecoilValue<roundInfoType>(roundInfoState);
     const [drawState, setDrawState] = useState(false);
-
-    // useEffect(() => {
-    // TODO: useEffect 안에서는 동작하지 않는 이유는 무엇일까?
-    getRoundInfo()
-        .then((res) => setRoundInfo(res))
-        .catch((err) => console.log(err));
-    // });
 
     useEffect(() => {
         if (roundInfo === undefined) return;
         setDrawState(roundInfo.type === 'DRAW');
     }, [roundInfo]);
+
+    // TODO: 유저리스트 가져와서 GameUsers 컴포넌트 구성하기
 
     return (
         <Container>


### PR DESCRIPTION
## 상세내용
- 기존에 Game 컴포넌트 안에서 호출하던 getRoundInfo를 useEffect 안에서는 사용할 수 없는 문제가 있었어요. Game 컴포넌트의 useEffect 안에서 함수 호출시 getRoundInfo안의 이벤트에미터가 이벤트를 받기위해(on) 부착되기도 전에 이벤트가 증발해버린 문제로 추측하고 있어요. 기능 확인을 위해 useEffect를 빼고 getRoundInfo 함수만 Game 컴포넌트 안에 넣어 동작시킨 것에서, 방장이 시작버튼을 누른 후 onStartGame에서 'start-game' on을  받을 때 그 안에서 실행되도록 변경했어요.
- 게임 시작하기 버튼과 관련 기능을 별도 컴포넌트로 분리했어요. GameModeList 컴포넌트가 복잡해보여서 가독성을 위해서 분리했어요.

## 기타
리팩터링 이전에 공부했던 자료 중 [context api로 socket을 관리하는 글](https://dev.to/bravemaster619/how-to-use-socket-io-client-correctly-in-react-app-o65)이 있었어요. 
저희처럼 규모가 크지않으면 유용해보여서 한번 읽어보면 좋을 것 같아요.