### PR TITLE
[feat] 'DRAW' 상태일 때 제출버튼을 누르면 드로잉이 비활성화 되는 기능

### DIFF
--- a/frontend/src/atoms/game.ts
+++ b/frontend/src/atoms/game.ts
@@ -34,8 +34,8 @@ export const roundDrawState = selector({
         const roundInfo = get(roundInfoState);
 
         if (roundInfo === undefined) return false;
-        // 인풋 확인을 위해 임시로 !==(반대로) 해놓음
-        return roundInfo.type !== 'DRAW';
+
+        return roundInfo.type === 'DRAW';
     },
 });
 
@@ -63,4 +63,9 @@ export const roundNumberState = selector({
 
         return roundInfo.round;
     },
+});
+
+export const submitState = atom<boolean>({
+    key: 'submitState',
+    default: false,
 });

--- a/frontend/src/components/DrawingTools.tsx
+++ b/frontend/src/components/DrawingTools.tsx
@@ -60,26 +60,6 @@ const Tools = styled.div`
     grid-template-rows: repeat(2, 1fr);
     grid-gap: 7px;
     margin-bottom: 44px;
-
-    button {
-        //펜 및 리셋 아이콘 위치 수정
-        svg {
-            transform: translateY(1px);
-        }
-    }
-    button:nth-of-type(2) {
-        //페인트 아이콘 위치 수정
-        svg {
-            transform: translate(-1px, -1px);
-        }
-    }
-
-    button:nth-of-type(3) {
-        //지우개 아이콘 위치 수정
-        svg {
-            transform: translate(3px, 3px);
-        }
-    }
 `;
 
 const Tool = styled.button<{ isSelected: boolean }>`
@@ -93,6 +73,25 @@ const Tool = styled.button<{ isSelected: boolean }>`
     border: 1px solid
         ${(props) => (props.isSelected ? props.theme.color.primaryDark : props.theme.color.brown)};
     box-shadow: ${({ theme }) => theme.shadow.btn};
+    &:first-of-type {
+        //펜 아이콘 위치 수정
+        img {
+            transform: translateY(2px);
+        }
+    }
+    &:nth-of-type(2) {
+        //페인트 아이콘 위치 수정
+        img {
+            transform: translateX(-1px);
+        }
+    }
+
+    &:nth-of-type(3) {
+        //지우개 아이콘 위치 수정
+        img {
+            transform: translate(3px, 4px);
+        }
+    }
 `;
 
 const ColorPicker = styled.div`

--- a/frontend/src/components/DrawingTools.tsx
+++ b/frontend/src/components/DrawingTools.tsx
@@ -4,8 +4,6 @@ import { colorName } from '@utils/constants';
 import HexColorPicker from './HexColorPicker';
 import { colors } from '@styles/ZelloTheme';
 import usePalette from '@hooks/usePalette';
-import { useRecoilValue } from 'recoil';
-import { roundDrawState } from '@atoms/game';
 
 interface PaletteType {
     onClickPen: (color: string) => void;
@@ -20,10 +18,9 @@ interface DrawingToolsType {
 
 function DrawingTools({ rest }: DrawingToolsType) {
     const { tools, selectedColor, selectedTool, onClickColor, onChangeTool } = usePalette(rest);
-    const isDraw = useRecoilValue(roundDrawState);
 
     return (
-        <Container isDraw={isDraw}>
+        <Container>
             <Tools>
                 {tools.map((tool, index) => (
                     <Tool
@@ -53,16 +50,15 @@ function DrawingTools({ rest }: DrawingToolsType) {
 
 export default DrawingTools;
 
-const Container = styled(Center)<{ isDraw: boolean }>`
+const Container = styled(Center)`
     flex-direction: column;
-    opacity: ${({ isDraw }) => (isDraw ? 1 : 0)};
 `;
 
 const Tools = styled.div`
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     grid-template-rows: repeat(2, 1fr);
-    grid-gap: 8px;
+    grid-gap: 7px;
     margin-bottom: 44px;
 
     button {

--- a/frontend/src/components/SketchbookCard.tsx
+++ b/frontend/src/components/SketchbookCard.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { Center } from '@styles/styled';
 import { ReactComponent as Sketchbook } from '@assets/sketchbook.svg';
 import { useRecoilValue } from 'recoil';
-import { roundDrawState, roundNumberState, roundWordState } from '@atoms/game';
+import { roundDrawState, roundNumberState, roundWordState, submitState } from '@atoms/game';
 import useCanvas from '@hooks/useCanvas';
 import Card from '@components/Card';
 import Timer from '@components/Timer';
@@ -13,8 +13,7 @@ function SketchbookCard() {
     const isDraw = useRecoilValue(roundDrawState);
     const word = useRecoilValue(roundWordState);
     const roundNum = useRecoilValue(roundNumberState);
-
-    // TODO: 첫라운드 일때만 스케치북에 설명 보여주기
+    const isSubmit = useRecoilValue(submitState);
 
     return (
         <Card>
@@ -39,7 +38,7 @@ function SketchbookCard() {
                         </FirstRoundGuide>
                     )}
                 </SketchbookWrapper>
-                <DrawingTools rest={rest} />
+                {isDraw && !isSubmit ? <DrawingTools rest={rest} /> : <div />}
             </Container>
         </Card>
     );
@@ -49,6 +48,9 @@ export default SketchbookCard;
 
 const Container = styled(Center)`
     padding: 44px 38px 0 28px;
+    > div:last-of-type {
+        width: 100%;
+    }
 `;
 
 const GameStateSection = styled.div`

--- a/frontend/src/components/SubmitSection.tsx
+++ b/frontend/src/components/SubmitSection.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Center } from '@styles/styled';
-import { useRecoilValue } from 'recoil';
-import { roundDrawState, roundNumberState, roundWordState } from '@atoms/game';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { roundDrawState, roundNumberState, roundWordState, submitState } from '@atoms/game';
 import PrimaryButton from '@components/PrimaryButton';
 
 function SubmitSection() {
@@ -11,8 +11,7 @@ function SubmitSection() {
     const roundWord = useRecoilValue(roundWordState);
     const [placeholder, setPlaceholder] = useState('그림을 보고 답을 맞춰보세요!');
     const [userAnswer, setUserAnswer] = useState('');
-    // TODO: recoil로 변경하고 DRAW 모드일때도 적용하기
-    const [isSubmit, setIsSubmit] = useState(false);
+    const [isSubmit, setIsSubmit] = useRecoilState(submitState);
 
     useEffect(() => {
         setRandomWordToPlaceholder();

--- a/frontend/src/hooks/useCanvas.ts
+++ b/frontend/src/hooks/useCanvas.ts
@@ -7,6 +7,8 @@ import {
     ERASER_COLOR,
     ERASER_LINE_WIDTH,
 } from '@utils/constants';
+import { useRecoilValue } from 'recoil';
+import { submitState } from '@atoms/game';
 
 interface Coordinate {
     x: number;
@@ -19,6 +21,7 @@ function useCanvas() {
 
     const [pos, setPos] = useState<Coordinate | undefined>({ x: 0, y: 0 });
     const [isPainting, setIsPainting] = useState<boolean>(false);
+    const isSubmit = useRecoilValue(submitState);
 
     const getCoordinates = (event: MouseEvent): Coordinate | undefined => {
         return { x: event.offsetX, y: event.offsetY };
@@ -56,6 +59,8 @@ function useCanvas() {
         (event: MouseEvent): void => {
             event.preventDefault();
             event.stopPropagation();
+
+            if (isSubmit) return;
 
             if (isPainting) {
                 const newPos = getCoordinates(event);


### PR DESCRIPTION
## 상세내용
- '제출하기' 버튼을 누르면 드로잉 도구들이 숨겨져요.
- '변경하기' 버튼을 누르면 드로잉 도구가 다시 나타나요.
- 드로잉 툴의 아이콘 위치가 중앙으로 수정되었어요.
- 제출(isSubmit) 상태일 경우 canvas 드로잉이 비활성화 되어요.

### 참고사항
- 제출 후 다시 변경하기 버튼을 눌렀을 때 새로운 색을 선택하지 않으면 canvas에는 마지막으로 사용한 색깔로 그려지지만 색상 선택 UI에서는 검정색(기본값)이 선택된 것처럼 나와요. 혜원님이 추가작업한 canvas 관련 코드와 병합 후 수정하기로 했어요.