### PR TITLE
[feat] 해상도에 상관없이 레이아웃이 깨지지않도록 수정

### DIFF
--- a/frontend/src/components/GameUsers.tsx
+++ b/frontend/src/components/GameUsers.tsx
@@ -20,7 +20,7 @@ export default GameUsers;
 
 const Container = styled(Center)`
     width: 100%;
-    max-width: 1728px;
+    max-width: 1820px;
     grid-gap: 8px;
-    margin-bottom: 56px;
+    margin-bottom: 40px;
 `;

--- a/frontend/src/components/GameUsers.tsx
+++ b/frontend/src/components/GameUsers.tsx
@@ -1,21 +1,16 @@
 import VideoCallUser from '@components/VideoCallUser';
 import styled from 'styled-components';
+import { useRecoilValue } from 'recoil';
+import { userListState } from '@atoms/game';
+import { Center } from '@styles/styled';
 
 function GameUsers() {
-    const testUsers = [
-        '젤로조아13579',
-        '젤로조아23579',
-        '젤로조아33579',
-        '젤로조아43579',
-        '젤로조아53579',
-        '젤로조아63579',
-        '젤로조아73579',
-        '젤로조아83579',
-    ];
+    const userList = useRecoilValue(userListState);
+
     return (
         <Container>
-            {testUsers.map((userName, index) => (
-                <VideoCallUser userName={userName} key={`${userName} ${index}`} />
+            {userList.map((user: string, idx: number) => (
+                <VideoCallUser key={`${user} ${idx}`} userName={user} />
             ))}
         </Container>
     );
@@ -23,11 +18,9 @@ function GameUsers() {
 
 export default GameUsers;
 
-const Container = styled.div`
+const Container = styled(Center)`
     width: 100%;
     max-width: 1728px;
-    display: grid;
-    grid-template-columns: repeat(8, 1fr);
     grid-gap: 8px;
     margin-bottom: 68px;
 `;

--- a/frontend/src/components/GameUsers.tsx
+++ b/frontend/src/components/GameUsers.tsx
@@ -20,7 +20,7 @@ export default GameUsers;
 
 const Container = styled(Center)`
     width: 100%;
-    max-width: 1728px;
+    max-width: 1820px;
     grid-gap: 8px;
-    margin-bottom: 56px;
+    margin-bottom: 48px;
 `;

--- a/frontend/src/components/GameUsers.tsx
+++ b/frontend/src/components/GameUsers.tsx
@@ -22,5 +22,5 @@ const Container = styled(Center)`
     width: 100%;
     max-width: 1728px;
     grid-gap: 8px;
-    margin-bottom: 68px;
+    margin-bottom: 56px;
 `;

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -12,12 +12,14 @@ function Game() {
     const [setPage] = useMovePage();
 
     return (
-        <Container>
-            <GameUsers />
-            <SketchbookSection>
-                <SketchbookCard />
-                <QuizReplySection />
-            </SketchbookSection>
+        <>
+            <Container>
+                <GameUsers />
+                <SketchbookSection>
+                    <SketchbookCard />
+                    <QuizReplySection />
+                </SketchbookSection>
+            </Container>{' '}
             <CamAndMicWrapper>
                 <CameraButton />
                 <MicButton />
@@ -25,21 +27,19 @@ function Game() {
             <LogoWrapper onClick={() => setPage('/')}>
                 <img src={SmallLogo} />
             </LogoWrapper>
-            <div />
-        </Container>
+        </>
     );
 }
 
 export default Game;
 
 const Container = styled(ScaledSection)`
-    justify-content: space-between;
     position: relative;
-    padding: 40px 36px;
+    padding: 0 36px 40px 36px;
 `;
 
 const SketchbookSection = styled.div`
-    margin-bottom: 120px;
+    margin-bottom: 140px;
 `;
 
 const CamAndMicWrapper = styled.div`

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -33,10 +33,7 @@ function Game() {
 export default Game;
 
 const Container = styled(ScaledSection)`
-    display: flex;
-    align-items: center;
     justify-content: space-between;
-    flex-direction: column;
     position: relative;
     padding: 40px 36px;
 `;

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { ScaledSection } from '@styles/styled';
 import SketchbookCard from '@components/SketchbookCard';
 import GameUsers from '@components/GameUsers';
 import MicButton from '@components/MicButton';
@@ -9,8 +10,6 @@ import QuizReplySection from '@components/QuizReplySection';
 
 function Game() {
     const [setPage] = useMovePage();
-
-    // TODO: 유저리스트 가져와서 GameUsers 컴포넌트 구성하기
 
     return (
         <Container>
@@ -33,9 +32,7 @@ function Game() {
 
 export default Game;
 
-const Container = styled.div`
-    width: 100%;
-    height: 100%;
+const Container = styled(ScaledSection)`
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -45,7 +42,7 @@ const Container = styled.div`
 `;
 
 const SketchbookSection = styled.div`
-    transform: translateY(-80px);
+    margin-bottom: 120px;
 `;
 
 const CamAndMicWrapper = styled.div`

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { ScaledSection } from '@styles/styled';
+import { ScaledDiv, ScaledSection } from '@styles/styled';
 import SketchbookCard from '@components/SketchbookCard';
 import GameUsers from '@components/GameUsers';
 import MicButton from '@components/MicButton';
@@ -12,12 +12,14 @@ function Game() {
     const [setPage] = useMovePage();
 
     return (
-        <Container>
-            <GameUsers />
-            <SketchbookSection>
-                <SketchbookCard />
-                <QuizReplySection />
-            </SketchbookSection>
+        <>
+            <Container>
+                <GameUsers />
+                <SketchbookSection>
+                    <SketchbookCard />
+                    <QuizReplySection />
+                </SketchbookSection>
+            </Container>{' '}
             <CamAndMicWrapper>
                 <CameraButton />
                 <MicButton />
@@ -25,24 +27,22 @@ function Game() {
             <LogoWrapper onClick={() => setPage('/')}>
                 <img src={SmallLogo} />
             </LogoWrapper>
-            <div />
-        </Container>
+        </>
     );
 }
 
 export default Game;
 
 const Container = styled(ScaledSection)`
-    justify-content: space-between;
     position: relative;
-    padding: 40px 36px;
+    padding: 48px 36px 40px 36px;
 `;
 
 const SketchbookSection = styled.div`
-    margin-bottom: 120px;
+    margin-bottom: 140px;
 `;
 
-const CamAndMicWrapper = styled.div`
+const CamAndMicWrapper = styled(ScaledDiv)`
     display: flex;
     position: absolute;
     bottom: 24px;
@@ -53,7 +53,7 @@ const CamAndMicWrapper = styled.div`
     }
 `;
 
-const LogoWrapper = styled.div`
+const LogoWrapper = styled(ScaledDiv)`
     justify-self: center;
     position: absolute;
     bottom: 40px;

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -14,6 +14,7 @@ import { useRecoilState } from 'recoil';
 import { userListState } from '@atoms/game';
 import { getParam } from '@utils/common';
 import { JoinLobbyReEmitRequest, JoinLobbyRequest } from '@backend/core/user.dto';
+import { ScaledSection } from '@styles/styled';
 
 function Lobby() {
     const [userList, setUserList] = useRecoilState(userListState);
@@ -73,6 +74,8 @@ function Lobby() {
 
 export default Lobby;
 
+const LobbyContainer = styled(ScaledSection)``;
+
 const LogoWrapper = styled.div`
     position: absolute;
     top: 12px;
@@ -81,14 +84,6 @@ const LogoWrapper = styled.div`
     img {
         cursor: pointer;
     }
-`;
-
-const LobbyContainer = styled.section`
-    display: flex;
-    height: 100%;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
 `;
 
 const FlexBox = styled.div`

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -55,10 +55,10 @@ function Lobby() {
 
     return (
         <>
+            <LogoWrapper onClick={() => setPage('/')}>
+                <img src={SmallLogo} />
+            </LogoWrapper>
             <LobbyContainer>
-                <LogoWrapper onClick={() => setPage('/')}>
-                    <img src={SmallLogo} />
-                </LogoWrapper>
                 <FlexBox>
                     <UserList />
                     <GameModeList lobbyId={lobbyId} />

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import styled from 'styled-components';
+import { ScaledDiv, ScaledSection } from '@styles/styled';
 import GameModeList from '@components/GameModeList';
 import UserList from '@components/UserList';
 import CameraButton from '@components/CameraButton';
@@ -14,7 +15,6 @@ import { useRecoilState } from 'recoil';
 import { userListState } from '@atoms/game';
 import { getParam } from '@utils/common';
 import { JoinLobbyReEmitRequest, JoinLobbyRequest } from '@backend/core/user.dto';
-import { ScaledSection } from '@styles/styled';
 
 function Lobby() {
     const [userList, setUserList] = useRecoilState(userListState);
@@ -55,10 +55,10 @@ function Lobby() {
 
     return (
         <>
+            <LogoWrapper onClick={() => setPage('/')}>
+                <img src={SmallLogo} />
+            </LogoWrapper>
             <LobbyContainer>
-                <LogoWrapper onClick={() => setPage('/')}>
-                    <img src={SmallLogo} />
-                </LogoWrapper>
                 <FlexBox>
                     <UserList />
                     <GameModeList lobbyId={lobbyId} />
@@ -76,13 +76,21 @@ export default Lobby;
 
 const LobbyContainer = styled(ScaledSection)``;
 
-const LogoWrapper = styled.div`
+const LogoWrapper = styled(ScaledDiv)`
     position: absolute;
     top: 12px;
-    left: 24px;
+    left: -12px;
 
     img {
         cursor: pointer;
+    }
+
+    @media (min-width: 2000px) {
+        left: 24px;
+    }
+    @media (min-width: 2500px) {
+        top: 24px;
+        left: 60px;
     }
 `;
 

--- a/frontend/src/pages/Lobby.tsx
+++ b/frontend/src/pages/Lobby.tsx
@@ -79,18 +79,10 @@ const LobbyContainer = styled(ScaledSection)``;
 const LogoWrapper = styled(ScaledDiv)`
     position: absolute;
     top: 12px;
-    left: -12px;
+    left: 12px;
 
     img {
         cursor: pointer;
-    }
-
-    @media (min-width: 2000px) {
-        left: 24px;
-    }
-    @media (min-width: 2500px) {
-        top: 24px;
-        left: 60px;
     }
 `;
 

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -10,6 +10,7 @@ import { useRecoilValue } from 'recoil';
 import { userState, userStateType } from '@atoms/user';
 import { networkServiceInstance as NetworkService } from '../services/socketService';
 import { getParam } from '@utils/common';
+import { ScaledSection } from '@styles/styled';
 
 function Main() {
     const [setPage] = useMovePage();
@@ -33,7 +34,7 @@ function Main() {
     return (
         <MainContainer>
             <LogoWrapper onClick={() => setPage('/')}>
-                <img src={Logo} />
+                <img src={Logo} alt={'Logo, Move to main page'} />
             </LogoWrapper>
             <CardContainer>
                 <UserCard />
@@ -49,12 +50,8 @@ function Main() {
 
 export default Main;
 
-const MainContainer = styled.section`
-    display: flex;
-    height: 100%;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
+const MainContainer = styled(ScaledSection)`
+    margin-top: -120px;
     gap: 16px;
 `;
 
@@ -69,6 +66,6 @@ const LogoWrapper = styled.div`
 
 const BottomWrapper = styled.div`
     position: absolute;
-    bottom: 0px;
-    right: 0px;
+    bottom: -40px;
+    right: 0;
 `;

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -32,19 +32,21 @@ function Main() {
     };
 
     return (
-        <MainContainer>
-            <LogoWrapper onClick={() => setPage('/')}>
-                <img src={Logo} alt={'Logo, Move to main page'} />
-            </LogoWrapper>
-            <CardContainer>
-                <UserCard />
-                <InfoCard onHandleEnterLobby={onClickEnterBtn} />
-            </CardContainer>
-            {!user.isHost && <GuestEntranceMessage />}
+        <>
+            <MainContainer>
+                <LogoWrapper onClick={() => setPage('/')}>
+                    <img src={Logo} alt={'Logo, Move to main page'} />
+                </LogoWrapper>
+                <CardContainer>
+                    <UserCard />
+                    <InfoCard onHandleEnterLobby={onClickEnterBtn} />
+                </CardContainer>
+                {!user.isHost && <GuestEntranceMessage />}
+            </MainContainer>
             <BottomWrapper>
                 <MadeByText />
             </BottomWrapper>
-        </MainContainer>
+        </>
     );
 }
 
@@ -66,6 +68,6 @@ const LogoWrapper = styled.div`
 
 const BottomWrapper = styled.div`
     position: absolute;
-    bottom: -40px;
-    right: 0;
+    bottom: 20px;
+    right: 16px;
 `;

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
+import { ScaledDiv, ScaledSection } from '@styles/styled';
 import UserCard from '@components/UserCard';
 import Logo from '@assets/logo-l.png';
 import InfoCard from '@components/InfoCard';
@@ -10,7 +11,6 @@ import { useRecoilValue } from 'recoil';
 import { userState, userStateType } from '@atoms/user';
 import { networkServiceInstance as NetworkService } from '../services/socketService';
 import { getParam } from '@utils/common';
-import { ScaledSection } from '@styles/styled';
 
 function Main() {
     const [setPage] = useMovePage();
@@ -32,19 +32,21 @@ function Main() {
     };
 
     return (
-        <MainContainer>
-            <LogoWrapper onClick={() => setPage('/')}>
-                <img src={Logo} alt={'Logo, Move to main page'} />
-            </LogoWrapper>
-            <CardContainer>
-                <UserCard />
-                <InfoCard onHandleEnterLobby={onClickEnterBtn} />
-            </CardContainer>
-            {!user.isHost && <GuestEntranceMessage />}
+        <>
+            <MainContainer>
+                <LogoWrapper onClick={() => setPage('/')}>
+                    <img src={Logo} alt={'Logo, Move to main page'} />
+                </LogoWrapper>
+                <CardContainer>
+                    <UserCard />
+                    <InfoCard onHandleEnterLobby={onClickEnterBtn} />
+                </CardContainer>
+                {!user.isHost && <GuestEntranceMessage />}
+            </MainContainer>
             <BottomWrapper>
                 <MadeByText />
             </BottomWrapper>
-        </MainContainer>
+        </>
     );
 }
 
@@ -64,8 +66,8 @@ const LogoWrapper = styled.div`
     cursor: pointer;
 `;
 
-const BottomWrapper = styled.div`
+const BottomWrapper = styled(ScaledDiv)`
     position: absolute;
-    bottom: -40px;
-    right: 0;
+    bottom: 20px;
+    right: 16px;
 `;

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -25,6 +25,9 @@ export const GlobalStyle = createGlobalStyle`
   }
 
   #root {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 100%;
     height: 100%;
   }

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -28,8 +28,10 @@ export const GlobalStyle = createGlobalStyle`
     display: flex;
     align-items: center;
     justify-content: center;
+    position: relative;
     width: 100%;
     height: 100%;
+    overflow: hidden;
   }
 
   button {

--- a/frontend/src/styles/ZelloTheme.ts
+++ b/frontend/src/styles/ZelloTheme.ts
@@ -1,4 +1,4 @@
-import { MAX_HEIGHT, MAX_WIDTH } from '@utils/constants';
+import { MAX_HEIGHT, MAX_WIDTH, SCALE } from '@utils/constants';
 
 interface ColorsType {
     [key: string]: string;
@@ -75,6 +75,6 @@ export const ZelloTheme = {
     layout: {
         maxWidth: `${MAX_WIDTH}px`,
         maxHeight: `${MAX_HEIGHT}px`,
-        sectionScale: `scale(${(window.innerWidth / MAX_WIDTH).toFixed(2)})`,
+        sectionScale: SCALE,
     },
 };

--- a/frontend/src/styles/ZelloTheme.ts
+++ b/frontend/src/styles/ZelloTheme.ts
@@ -1,3 +1,5 @@
+import { MAX_HEIGHT, MAX_WIDTH } from '@utils/constants';
+
 interface ColorsType {
     [key: string]: string;
 }
@@ -68,5 +70,10 @@ export const ZelloTheme = {
         card: '0px 6px 9px 2px rgba(0, 29, 46, 0.2)',
         icon: '0px 1px 3px 1px rgba(0, 29, 46, 0.5)',
         btn: '0px 1px 3px 1px rgba(0, 29, 46, 0.3)',
+    },
+    layout: {
+        maxWidth: `${MAX_WIDTH}px`,
+        maxHeight: `${MAX_HEIGHT}px`,
+        sectionScale: `scale(${(window.innerWidth / MAX_WIDTH).toFixed(2)})`,
     },
 };

--- a/frontend/src/styles/ZelloTheme.ts
+++ b/frontend/src/styles/ZelloTheme.ts
@@ -71,6 +71,7 @@ export const ZelloTheme = {
         icon: '0px 1px 3px 1px rgba(0, 29, 46, 0.5)',
         btn: '0px 1px 3px 1px rgba(0, 29, 46, 0.3)',
     },
+
     layout: {
         maxWidth: `${MAX_WIDTH}px`,
         maxHeight: `${MAX_HEIGHT}px`,

--- a/frontend/src/styles/styled.ts
+++ b/frontend/src/styles/styled.ts
@@ -18,6 +18,10 @@ export const Color = styled.input<{ colorName: string; isSelected: boolean }>`
 `;
 
 export const ScaledSection = styled.section`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
     width: ${({ theme }) => theme.layout.maxWidth};
     height: ${({ theme }) => theme.layout.maxHeight};
     transform: ${({ theme }) => theme.layout.sectionScale};

--- a/frontend/src/styles/styled.ts
+++ b/frontend/src/styles/styled.ts
@@ -26,3 +26,7 @@ export const ScaledSection = styled.section`
     height: ${({ theme }) => theme.layout.maxHeight};
     transform: ${({ theme }) => theme.layout.sectionScale};
 `;
+
+export const ScaledDiv = styled.div`
+    transform: ${({ theme }) => theme.layout.sectionScale};
+`;

--- a/frontend/src/styles/styled.ts
+++ b/frontend/src/styles/styled.ts
@@ -16,3 +16,9 @@ export const Color = styled.input<{ colorName: string; isSelected: boolean }>`
     border: ${({ isSelected }) => (isSelected ? `3px solid rgba(246, 245, 248, 0.6)` : ``)};
     cursor: pointer;
 `;
+
+export const ScaledSection = styled.section`
+    width: ${({ theme }) => theme.layout.maxWidth};
+    height: ${({ theme }) => theme.layout.maxHeight};
+    transform: ${({ theme }) => theme.layout.sectionScale};
+`;

--- a/frontend/src/styles/styled.ts
+++ b/frontend/src/styles/styled.ts
@@ -24,9 +24,10 @@ export const ScaledSection = styled.section`
     flex-direction: column;
     width: ${({ theme }) => theme.layout.maxWidth};
     height: ${({ theme }) => theme.layout.maxHeight};
-    transform: ${({ theme }) => theme.layout.sectionScale};
+    transform: scale(${({ theme }) => theme.layout.sectionScale});
 `;
 
 export const ScaledDiv = styled.div`
-    transform: ${({ theme }) => theme.layout.sectionScale};
+    transform: ${({ theme }) =>
+        theme.layout.sectionScale < 1 ? `scale(${theme.layout.sectionScale})` : 'scale(1)'};
 `;

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -25,5 +25,5 @@ export const PEN_LINE_WIDTH = 5;
 export const PEN_DEFAULT_COLOR = '#001D2E';
 export const ERASER_COLOR = '#F6F5F8';
 export const ERASER_LINE_WIDTH = 20;
-export const MAX_WIDTH = 2400;
-export const MAX_HEIGHT = 1200;
+export const MAX_WIDTH = 2000;
+export const MAX_HEIGHT = 1050;

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -25,3 +25,5 @@ export const PEN_LINE_WIDTH = 5;
 export const PEN_DEFAULT_COLOR = '#001D2E';
 export const ERASER_COLOR = '#F6F5F8';
 export const ERASER_LINE_WIDTH = 20;
+export const MAX_WIDTH = 2400;
+export const MAX_HEIGHT = 1200;

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -27,3 +27,4 @@ export const ERASER_COLOR = '#F6F5F8';
 export const ERASER_LINE_WIDTH = 20;
 export const MAX_WIDTH = 2000;
 export const MAX_HEIGHT = 1050;
+export const SCALE = Number((window.innerWidth / MAX_WIDTH).toFixed(2));

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -25,5 +25,5 @@ export const PEN_LINE_WIDTH = 5;
 export const PEN_DEFAULT_COLOR = '#001D2E';
 export const ERASER_COLOR = '#F6F5F8';
 export const ERASER_LINE_WIDTH = 20;
-export const MAX_WIDTH = 2400;
-export const MAX_HEIGHT = 1200;
+export const MAX_WIDTH = 2200;
+export const MAX_HEIGHT = 1050;


### PR DESCRIPTION
## 상세내용
- 15인치 맥북에서나 32인치 모니터에서나 레이아웃이 깨지지 않아요.
- 너~무 작거나 큰 해상도에서는 적당한 레이아웃로 보이지않을 수 있으나 보편적으로 사용되는 pc 해상도에서는 문제없어보여요(테스트 완료)
- 갈틱폰을 참고하여 UI의 scale을 조절하여 화면에 맞는 사이즈로 보여주게 했어요. %를 이용하는 대신 scale을 이용해서 이후에 캔바스를 이미지로 저장할때 화면 크기에 상관없이 동일한 크기로 저장될 것 같아요.(테스트 필요)