### PR TITLE
[feat] 라운드 타임아웃시 새 라운드가 시작되는 기능

### DIFF
--- a/backend/src/core/core.gateway.ts
+++ b/backend/src/core/core.gateway.ts
@@ -160,9 +160,13 @@ export class CoreGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     private emitRoundTimeout(client: Socket, lobbyId: string) {
         const game = this.gameService.getGame(lobbyId);
         setTimeout(() => {
-            this.gameService.getNotSubmittedUsers(lobbyId).forEach((user) => {
-                client.nsp.to(user.socketId).emit('round-timeout');
-            });
+            try {
+                this.gameService.getNotSubmittedUsers(lobbyId).forEach((user) => {
+                    client.nsp.to(user.socketId).emit('round-timeout');
+                });
+            } catch (e) {
+                console.log('종료된 게임입니다.');
+            }
         }, game.getRoundLimitTime() * 1000);
     }
 

--- a/backend/src/core/core.gateway.ts
+++ b/backend/src/core/core.gateway.ts
@@ -154,6 +154,16 @@ export class CoreGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
             };
             client.nsp.to(user.socketId).emit('start-round', payload);
         });
+        this.emitRoundTimeout(client, lobbyId);
+    }
+
+    private emitRoundTimeout(client: Socket, lobbyId: string) {
+        const game = this.gameService.getGame(lobbyId);
+        setTimeout(() => {
+            this.gameService.getNotSubmittedUsers(lobbyId).forEach((user) => {
+                client.nsp.to(user.socketId).emit('round-timeout');
+            });
+        }, game.getRoundLimitTime() * 1000);
     }
 
     private emitSubmitQuizReply(

--- a/backend/src/core/game.service.ts
+++ b/backend/src/core/game.service.ts
@@ -17,7 +17,7 @@ export class GameService {
     startGame(lobbyId: string) {
         const game = this.getGame(lobbyId);
         // TODO: Round 별 시간 관련 로직 추가 필요
-        game.startGame(60);
+        game.startGame();
         this.gameLobbyRepository.save(game);
     }
 

--- a/backend/src/core/game.service.ts
+++ b/backend/src/core/game.service.ts
@@ -38,6 +38,11 @@ export class GameService {
         return game.getSubmittedQuizRepliesCount();
     }
 
+    getNotSubmittedUsers(lobbyId: string): User[] {
+        const game = this.getGame(lobbyId);
+        return game.getNotSubmittedUsers();
+    }
+
     isAllUserSubmittedQuizReply(lobbyId: string): boolean {
         const game = this.getGame(lobbyId);
         return game.isAllUserSubmittedQuizReply();

--- a/backend/src/core/gameLobby.model.ts
+++ b/backend/src/core/gameLobby.model.ts
@@ -44,6 +44,10 @@ export class GameLobby implements Lobby, Game {
         return this.host;
     }
 
+    getRoundLimitTime(): number {
+        return this.roundLimitTime;
+    }
+
     joinLobby(user: User) {
         this.users.push(user);
     }
@@ -53,11 +57,11 @@ export class GameLobby implements Lobby, Game {
     }
 
     // TODO: 게임 시작시, 혹은 게임 종료 시 프로퍼티 초기화 로직 필요.
-    startGame(roundLimitTime: number) {
+    startGame() {
         this.maxRound = this.users.length - 1;
-        this.roundLimitTime = roundLimitTime;
         this.isPlaying = true;
         this.roundType = 'ANSWER';
+        this.roundLimitTime = 60;
         this.quizReplyChains = this.users.map(() => {
             const quizReplyChain = new QuizReplyChain();
             // TODO: 랜덤 키워드는 외부 모듈에 의존하도록 수정
@@ -107,7 +111,13 @@ export class GameLobby implements Lobby, Game {
     }
 
     private swapRoundType() {
-        this.roundType = this.roundType === 'DRAW' ? 'ANSWER' : 'DRAW';
+        if (this.roundType === 'ANSWER') {
+            this.roundType = 'DRAW';
+            this.roundLimitTime = 60;
+        } else {
+            this.roundType = 'ANSWER';
+            this.roundLimitTime = 30;
+        }
     }
 
     private getUserIndex(user: User): number {

--- a/backend/src/core/gameLobby.model.ts
+++ b/backend/src/core/gameLobby.model.ts
@@ -100,6 +100,18 @@ export class GameLobby implements Lobby, Game {
         ).length;
     }
 
+    getNotSubmittedUsers() {
+        return this.submittedQuizRepliesOnCurrentRound.reduce(
+            (acc: User[], quizReply: QuizReply | undefined, idx: number) => {
+                if (quizReply === undefined) {
+                    acc.push(this.users[idx]);
+                }
+                return acc;
+            },
+            [],
+        );
+    }
+
     isAllUserSubmittedQuizReply(): boolean {
         return this.submittedQuizRepliesOnCurrentRound.every(
             (quizReply) => quizReply !== undefined,

--- a/frontend/src/atoms/game.ts
+++ b/frontend/src/atoms/game.ts
@@ -36,11 +36,7 @@ export const quizReplyState = selector({
     get: ({ get }) => {
         const roundInfo = get(roundInfoState);
 
-        if (
-            roundInfo === undefined ||
-            roundInfo.quizReply.content === undefined ||
-            (roundInfo.roundType === 'DRAW' && roundInfo.quizReply.content.length > 100) // 100자 이상이면 그림 => 이전 유저가 답변을 안한 경우
-        ) {
+        if (roundInfo === undefined || roundInfo.quizReply.content === undefined) {
             return '';
         }
 

--- a/frontend/src/components/QuizReplySection.tsx
+++ b/frontend/src/components/QuizReplySection.tsx
@@ -20,7 +20,9 @@ function QuizReplySection() {
     const { placeholder, sendRandomWordReplyToServer } = useZeroRound(curRound);
 
     useEffect(() => {
+        // 라운드가 새로 시작하면 제출 상태와 유저 답변을 초기화한다.
         setQuizSubmitted(false);
+        setUserReply('');
     }, [curRound]);
 
     function submitBtnHandler() {

--- a/frontend/src/components/QuizReplySection.tsx
+++ b/frontend/src/components/QuizReplySection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { Center } from '@styles/styled';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -11,6 +11,7 @@ import {
 import PrimaryButton from '@components/PrimaryButton';
 import { emitSubmitQuizReply } from '@game/NetworkServiceUtils';
 import useZeroRound from '@hooks/useZeroRound';
+import useRoundTimeout from '@hooks/useRoundTimeout';
 
 function QuizReplySection() {
     const isDraw = useRecoilValue(isQuizTypeDrawState);
@@ -18,12 +19,19 @@ function QuizReplySection() {
     const [userReply, setUserReply] = useRecoilState(userReplyState);
     const [quizSubmitted, setQuizSubmitted] = useRecoilState(quizSubmitState);
     const { placeholder, sendRandomWordReplyToServer } = useZeroRound(curRound);
+    const { isRoundTimeout } = useRoundTimeout();
 
     useEffect(() => {
         // 라운드가 새로 시작하면 제출 상태와 유저 답변을 초기화한다.
         setQuizSubmitted(false);
         setUserReply('');
     }, [curRound]);
+
+    useEffect(() => {
+        if (isRoundTimeout) {
+            sendUserReplyToServer();
+        }
+    }, [isRoundTimeout]);
 
     function submitBtnHandler() {
         setQuizSubmitted(!quizSubmitted);

--- a/frontend/src/components/QuizReplySection.tsx
+++ b/frontend/src/components/QuizReplySection.tsx
@@ -38,7 +38,9 @@ function QuizReplySection() {
 
     function sendUserReplyToServer() {
         // 유저가 입력한 값이 서버로 제출된다.
-        emitSubmitQuizReply({ quizReply: { type: 'ANSWER', content: userReply } });
+        emitSubmitQuizReply({
+            quizReply: { type: isDraw ? 'DRAW' : 'ANSWER', content: userReply },
+        });
     }
 
     return (

--- a/frontend/src/game/NetworkServiceUtils.ts
+++ b/frontend/src/game/NetworkServiceUtils.ts
@@ -35,3 +35,7 @@ export const onSubmitQuizReply = () => {
         },
     );
 };
+
+export const onRoundTimeout = (setIsRoundTimeout: SetterOrUpdater<boolean>) => {
+    NetworkService.on('round-timeout', () => setIsRoundTimeout(true));
+};

--- a/frontend/src/hooks/useRoundTimeout.ts
+++ b/frontend/src/hooks/useRoundTimeout.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { onRoundTimeout } from '@game/NetworkServiceUtils';
+import { useRecoilValue } from 'recoil';
+import { roundNumberState } from '@atoms/game';
+
+function useRoundTimeout() {
+    const [isRoundTimeout, setIsRoundTimeout] = useState(false);
+    const { curRound } = useRecoilValue(roundNumberState);
+
+    useEffect(() => {
+        onRoundTimeout(setIsRoundTimeout);
+    }, []);
+
+    useEffect(() => {
+        setIsRoundTimeout(false);
+    }, [curRound]);
+
+    return { isRoundTimeout };
+}
+
+export default useRoundTimeout;


### PR DESCRIPTION
## 상세내용
- 서버에서 각 라운드별 타임이 종료되면 답을 제출하지 않은 유저의 클라이언트로 'round-timeout' 이벤트를 보내요.
- 클라이언트는 'round-timeout' 이벤트를 받으면 현재 상태의 답을 제출해요. 