### PR TITLE
[fix] GameLobby의 SucceedHost 메서드 수정

### DIFF
--- a/backend/src/core/gameLobby.model.ts
+++ b/backend/src/core/gameLobby.model.ts
@@ -83,7 +83,7 @@ export class GameLobby implements Lobby, Game {
 
     succeedHost() {
         const hostIdx = this.getUserIndex(this.host);
-        this.host = this.users[hostIdx + 1];
+        this.host = hostIdx === 0 ? this.users[1] : this.users[0];
     }
 
     // TODO: 게임 시작시, 혹은 게임 종료 시 프로퍼티 초기화 로직 필요.


### PR DESCRIPTION
## 상세내용
현재 호스트의 userIndex가 0일 경우 userIndex가 1인 유저가 다음 호스트, 현재 호스트의 userIndex가 1일 경우 userIndex가 0인 유저가 다음 호스트가 되도록 구현.

- Intent 
- 호스트 제외 가장 먼저 들어온 유저에게 Host 권한을 넘김

https://github.com/boostcampwm-2022/web37-ZelloDraw/pull/50#discussion_r1040366824