### PR TITLE
[feat] countdown애니메이션, 타이머 애니메이션 개선

### DIFF
--- a/frontend/src/components/CountDown.tsx
+++ b/frontend/src/components/CountDown.tsx
@@ -1,0 +1,60 @@
+import { motion } from 'framer-motion';
+import styled from 'styled-components';
+import { Center } from '@styles/styled';
+import { countDownContainerVariants, countDownVariants } from '@utils/framerMotion';
+
+function CountDown() {
+    return (
+        <Container
+            variants={countDownContainerVariants}
+            initial={'enter'}
+            animate={'animate'}
+            exit={'exit'}
+            transition={{ type: 'spring', staggerChildren: 0.7 }}
+        >
+            <motion.div variants={countDownVariants}>3</motion.div>
+            <motion.div variants={countDownVariants}>2</motion.div>
+            <motion.div variants={countDownVariants}>1</motion.div>
+        </Container>
+    );
+}
+
+export default CountDown;
+
+const Container = styled(motion(Center))`
+    width: 100%;
+    height: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 100;
+    background-color: ${({ theme }) => theme.color.primary};
+
+    > div {
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-family: 'Sniglet', cursive;
+        font-weight: 800;
+        font-size: 200px;
+    }
+
+    > div:first-of-type {
+        color: ${({ theme }) => theme.color.green};
+    }
+
+    > div:nth-of-type(2) {
+        background-color: ${({ theme }) => theme.color.green};
+        color: ${({ theme }) => theme.color.primary};
+    }
+
+    > div:nth-of-type(3) {
+        background-color: ${({ theme }) => theme.color.primary};
+        color: ${({ theme }) => theme.color.yellow};
+    }
+`;

--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -1,35 +1,22 @@
 import { ReactComponent as TimerIcon } from '@assets/icons/timer-icon.svg';
-import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 import { Center } from '@styles/styled';
-import { roundInfoState, roundNumberState } from '@atoms/game';
-import useTimer from '@hooks/useTimer';
+import { roundInfoState } from '@atoms/game';
+import { motion } from 'framer-motion';
 
 function Timer() {
-    const [progress, setProgress] = useState<number>(100);
     const roundInfo = useRecoilValue(roundInfoState);
-    const { curRound } = useRecoilValue(roundNumberState);
-    const { limitTime, timeLeft, isTimeOver, setTimerTime } = useTimer({
-        interval: 1000,
-        clearTimerDeps: curRound,
-    });
-
-    useEffect(() => {
-        if (roundInfo === undefined) return;
-        setTimerTime(roundInfo.limitTime);
-    }, [roundInfo]);
-
-    useEffect(() => {
-        // 프로그레스바의 높이를 설정
-        setProgress(timeLeft / limitTime);
-    }, [timeLeft]);
 
     return (
         <Container>
             <ProgressBar>
                 <Bar />
-                <Progress progress={progress} isTimeOver={isTimeOver} />
+                <Progress
+                    initial={{ height: '100%' }}
+                    animate={{ height: '0%' }}
+                    transition={{ duration: roundInfo?.limitTime || 60 }}
+                />
             </ProgressBar>
             <TimerIcon />
         </Container>
@@ -57,17 +44,14 @@ const Bar = styled.div`
     border-radius: 999px;
 `;
 
-const Progress = styled.div<{ progress: number; isTimeOver: boolean }>`
+const Progress = styled(motion.div)`
     width: 100%;
     height: 100%;
     transform-origin: bottom;
-    transform: scaleY(${({ progress }) => progress});
     position: absolute;
     bottom: 0;
     left: 0;
     background: ${({ theme }) => theme.gradation.primaryLightBrown};
     border: 1px solid ${({ theme }) => theme.color.whiteT2};
     border-radius: 24px;
-    opacity: ${({ isTimeOver }) => (isTimeOver ? 0 : 1)};
-    transition: transform 1s linear;
 `;

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -15,6 +15,8 @@ import { networkServiceInstance as NetworkService } from '../services/socketServ
 import { JoinLobbyReEmitRequest } from '@backend/core/user.dto';
 import { userState } from '@atoms/user';
 import useBeforeReload from '@hooks/useBeforeReload';
+import CountDown from '@components/CountDown';
+import { AnimatePresence } from 'framer-motion';
 
 function Game() {
     const [user, setUser] = useRecoilState(userState);
@@ -22,8 +24,12 @@ function Game() {
     const setUserStreamList = useSetRecoilState(userStreamListState);
     const setSubmittedQuizReplyCount = useSetRecoilState(submittedQuizReplyCountState);
     const [isCompleteGame, setIsCompleteGame] = useState(false);
+    const [isStarted, setIsStarted] = useState(false);
     useBeforeReload();
 
+    useEffect(() => {
+        setTimeout(() => setIsStarted(true), 2500);
+    }, []);
     useEffect(() => {
         onCountSubmittedQuiz(setSubmittedQuizReplyCount);
         onCompleteGame(setGameResult, setIsCompleteGame);
@@ -42,10 +48,11 @@ function Game() {
             NetworkService.off('leave-game');
             NetworkService.off('succeed-host');
         };
-    }, []);
+    }, [isStarted]);
 
     return (
         <>
+            <AnimatePresence>{!isStarted && <CountDown />}</AnimatePresence>
             <Container>
                 <GameUsers />
                 <SketchbookSection>

--- a/frontend/src/utils/framerMotion.ts
+++ b/frontend/src/utils/framerMotion.ts
@@ -42,3 +42,31 @@ export const flipVariants = {
         };
     },
 };
+
+export const countDownContainerVariants = {
+    enter: {
+        opacity: 1,
+    },
+    animate: {
+        opacity: 1,
+    },
+    exit: {
+        opacity: 0,
+    },
+};
+
+export const countDownVariants = {
+    enter: {
+        opacity: [0, 1],
+        scale: 1,
+        x: 0,
+    },
+    animate: {
+        opacity: 1,
+        scale: 15,
+        transition: {
+            opacity: { duration: 0.5 },
+            scale: { duration: 1.5 },
+        },
+    },
+};


### PR DESCRIPTION
## 상세내용
- 게임을 시작하면 3초 카운트다운 애니메이션이 실행되어요.  기존 구현하려고 했던 숫자가 화면을 덮으면서 다음 숫자가 나오는 애니메이션은 테스트 후 성능 문제로 현재의 적당한 크기까지만 커지는 애니메이션으로 변경되었어요. 대신 배경화면 색상도 변할 수 있게 적용했어요.
- 타이머 애니메이션을 setTimeout없이 duration을 이용해서 구현하는 것으로 변경했어요. scaleY값으로 높이를 조절하면 더 나은 성능을 얻을 수 있지만 border-radius가 적용된 둥근 부분이 시간이 흐름에 따라 납작해져서 height를 변경하는 애니메이션으로 구현했어요.