### PR TITLE
[feat] 유저에게 유저네임 변경할 수 있는 걸 알리는 안내문구 추가

### DIFF
--- a/frontend/src/components/MainVideoCall.tsx
+++ b/frontend/src/components/MainVideoCall.tsx
@@ -45,7 +45,7 @@ const Container = styled.div`
 `;
 
 const Video = styled(VideoProperty)`
-    border-radius: 32px;
+    border-radius: 30px;
 `;
 
 const CameraOffUserName = styled(Center)`

--- a/frontend/src/components/MainVideoCall.tsx
+++ b/frontend/src/components/MainVideoCall.tsx
@@ -23,9 +23,9 @@ function MainVideoCall({ userName, stream, video }: VideoCallProps) {
             ) : (
                 <>
                     <CameraOffUserName>
-                        <span>&#123;</span>
+                        <span>{'{'}</span>
                         <span>{userName}</span>
-                        <span>&#125;</span>
+                        <span>{'}'}</span>
                     </CameraOffUserName>
                 </>
             )}

--- a/frontend/src/components/UserCard.tsx
+++ b/frontend/src/components/UserCard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useEffect } from 'react';
+import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 import Card from '@components/Card';
 import CameraButton from '@components/CameraButton';
@@ -9,16 +9,23 @@ import { networkServiceInstance as NetworkService } from '../services/socketServ
 import { debounce } from 'lodash';
 import useLocalStream from '@hooks/useLocalStream';
 import MainVideoCall from '@components/MainVideoCall';
+import { Center } from '@styles/styled';
+import { motion } from 'framer-motion';
+import { opacityVariants } from '@utils/framerMotion';
 
 function UserCard() {
     const [user, setUserState] = useRecoilState(userState);
     const userCam = useRecoilValue(userCamState);
     const currentUser = useRecoilValue(userState);
     const selfStream = useRecoilValue(userStreamState);
+    const [isFirstUserNameChanging, setIsFirstUserNameChanging] = useState(true);
 
     useLocalStream();
 
     const onChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
+        // 유저 이름을 바꾼 적 있는지 확인
+        isFirstUserNameChanging && setIsFirstUserNameChanging(false);
+
         const name = e.target.value;
         setUserState({ ...user, name });
         debounceOnChange(name);
@@ -45,6 +52,15 @@ function UserCard() {
                     />
                     <span>{'}'}</span>
                 </UserName>
+                {isFirstUserNameChanging && (
+                    <Blink
+                        animate={'enter'}
+                        variants={opacityVariants}
+                        transition={{ repeat: Infinity, repeatType: 'reverse', duration: 0.5 }}
+                    >
+                        WRITE YOUR USERNAME
+                    </Blink>
+                )}
                 <ButtonWrapper>
                     <CameraButton />
                     <MicButton />
@@ -56,13 +72,15 @@ function UserCard() {
 
 export default UserCard;
 
-const CardInner = styled.div`
+const CardInner = styled(Center)`
+    flex-direction: column;
     padding: 16px;
     height: 100%;
 `;
 
 const UserName = styled.div`
     text-align: center;
+
     span {
         // 중괄호
         color: ${({ theme }) => theme.color.whiteT2};
@@ -83,7 +101,7 @@ const ButtonWrapper = styled.div`
 `;
 
 const NameInput = styled.input`
-    width: 201px;
+    width: 200px;
     background: transparent;
     text-align: center;
     margin: 0 2px;
@@ -95,4 +113,13 @@ const NameInput = styled.input`
     letter-spacing: -0.05em;
     color: ${({ theme }) => theme.color.yellow};
     -webkit-text-stroke: 1px ${({ theme }) => theme.color.blackT1};
+`;
+
+const Blink = styled(motion.div)`
+    position: absolute;
+    margin-top: 110px;
+    color: ${({ theme }) => theme.color.yellow};
+    font-family: 'Sniglet', cursive;
+    font-size: ${({ theme }) => theme.typo.h5};
+    letter-spacing: 0.02em;
 `;

--- a/frontend/src/components/UserCard.tsx
+++ b/frontend/src/components/UserCard.tsx
@@ -36,14 +36,14 @@ function UserCard() {
             <CardInner>
                 <MainVideoCall userName={currentUser.name} stream={selfStream} video={userCam} />
                 <UserName>
-                    <span>&#123;</span>
+                    <span>{'{'}</span>
                     <NameInput
                         type='text'
                         placeholder={user.name}
                         onChange={onChangeName}
                         maxLength={7}
                     />
-                    <span>&#125;</span>
+                    <span>{'}'}</span>
                 </UserName>
                 <ButtonWrapper>
                     <CameraButton />

--- a/frontend/src/components/UserCard.tsx
+++ b/frontend/src/components/UserCard.tsx
@@ -1,17 +1,17 @@
 import React, { useCallback, useState } from 'react';
-import styled from 'styled-components';
-import Card from '@components/Card';
-import CameraButton from '@components/CameraButton';
-import MicButton from '@components/MicButton';
-import { userState, userStreamState, userCamState, userMicState } from '@atoms/user';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { networkServiceInstance as NetworkService } from '../services/socketService';
 import { debounce } from 'lodash';
-import useLocalStream from '@hooks/useLocalStream';
-import MainVideoCall from '@components/MainVideoCall';
+import styled from 'styled-components';
 import { Center } from '@styles/styled';
 import { motion } from 'framer-motion';
 import { opacityVariants } from '@utils/framerMotion';
+import { userState, userStreamState, userCamState } from '@atoms/user';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { networkServiceInstance as NetworkService } from '../services/socketService';
+import Card from '@components/Card';
+import CameraButton from '@components/CameraButton';
+import MicButton from '@components/MicButton';
+import useLocalStream from '@hooks/useLocalStream';
+import MainVideoCall from '@components/MainVideoCall';
 
 function UserCard() {
     const [user, setUserState] = useRecoilState(userState);

--- a/frontend/src/components/UserCard.tsx
+++ b/frontend/src/components/UserCard.tsx
@@ -68,7 +68,7 @@ const UserName = styled.div`
         color: ${({ theme }) => theme.color.whiteT2};
         font-family: 'Sniglet', cursive;
         font-weight: 800;
-        font-size: 2rem;
+        font-size: 2.5rem;
         padding: 4px;
     }
 `;


### PR DESCRIPTION
## 상세내용
- 유저가 유저네임을 변경할 수 있는 걸 인지하게 하는 안내문구를 추가했어요. 깜빡이는 모션이 적용되었어요. 유저가 유저네임을 입력하면 UI가 사라져요.
- 유저카드의 중괄호 { } 아이콘 크기가 변경되었어요.
- 유저카드 비디오와 배경 네모의 border-radius가 달라서 보이는 빈 틈이 보이지 않도록 조정했어요.