### PR TITLE
fix: [BE] 4명 중에 3명이 제출하면 3/4가 아닌 1/4가 되는 버그 해결

### DIFF
--- a/backend/src/core/gameLobby.model.ts
+++ b/backend/src/core/gameLobby.model.ts
@@ -148,7 +148,7 @@ export class GameLobby implements Lobby, Game {
     }
 
     getSubmittedQuizRepliesCount(): number {
-        return this.submittedQuizRepliesOnCurrentRound.filter((quizReply) => quizReply == undefined)
+        return this.submittedQuizRepliesOnCurrentRound.filter((quizReply) => quizReply != undefined)
             .length;
     }
 


### PR DESCRIPTION
* gameLobby의 getSubmittedQuizRepliesCount() 메서드에서 필터링 조건 반대로 적용되어있던걸 수정함.

