### PR TITLE
[fix]: 로비인원수가 한명이 차이나게 나타나는 문제 해결

### DIFF
--- a/frontend/src/components/UserList.tsx
+++ b/frontend/src/components/UserList.tsx
@@ -20,7 +20,7 @@ function UserList() {
             <CardInner>
                 <FlexBox>
                     <CountBox>
-                        <PlayerCountText>{userList.length}</PlayerCountText>
+                        <PlayerCountText>{userList.length + 1}</PlayerCountText>
                         <PlayerCountSlash>/</PlayerCountSlash>
                         <PlayerCountText>8</PlayerCountText>
                     </CountBox>


### PR DESCRIPTION
## 상세내용
join-lobby 이벤트의 res에서 본인을 제외하고 userList에 저장하고 있어서 발생한 문제에요. userList를 표시하는 부분에서 +1을 해주었어요.