### PR TITLE
[fix] 타이머 작동안하는 버그 수정

### DIFF
--- a/backend/src/core/core.gateway.ts
+++ b/backend/src/core/core.gateway.ts
@@ -284,8 +284,10 @@ export class CoreGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         setTimeout(async () => {
             try {
-                (await this.gameService.getNotSubmittedUsers(lobbyId)).forEach((user) => {
-                    client.nsp.to(user.socketId).emit('round-timeout');
+                (await this.gameService.getNotSubmittedUsers(lobbyId)).forEach((user, index) => {
+                    setTimeout(() => {
+                        client.nsp.to(user.socketId).emit('round-timeout');
+                    }, index * 100);
                 });
             } catch (e) {
                 console.log('종료된 게임입니다.');

--- a/backend/src/core/gameLobby.model.ts
+++ b/backend/src/core/gameLobby.model.ts
@@ -163,7 +163,7 @@ export class GameLobby implements Lobby, Game {
     getNotSubmittedUsers() {
         return this.submittedQuizRepliesOnCurrentRound.reduce(
             (acc: User[], quizReply: QuizReply | undefined, idx: number) => {
-                if (quizReply === undefined) {
+                if (quizReply == undefined) {
                     acc.push(this.users[idx]);
                 }
                 return acc;


### PR DESCRIPTION
## 상세내용
* getNotSubmittedUsers 메서드의 filter 조건 변경
* 제출하지 않은 유저에게 round-timeout을 한번에 보내다 보니 클라이언트에서 submit-quiz-reply 이벤트를 동시에 전송함.
* submit-quiz-reply를 동시에 받다보니 getSubmittedQuizRepliesCount 호출의 결과가 같아지는 경우가 발생함
* round-timeout 이벤트 emit을 setTimeout을 이용해 순차적으로 보내도록 덕테이핑