### PR TITLE
[fix] 타이머 및 결과공유페이지 관련 버그 해결

### DIFF
--- a/frontend/src/components/Timer.tsx
+++ b/frontend/src/components/Timer.tsx
@@ -17,12 +17,12 @@ function Timer() {
                     <motion.div
                         initial={{ y: 1 }}
                         animate={{ y: 437 }}
-                        transition={{ duration: limitTime }}
+                        transition={{ duration: limitTime, ease: 'linear' }}
                     />
                     <motion.div
                         initial={{ scaleY: 1 }}
                         animate={{ scaleY: 0 }}
-                        transition={{ duration: limitTime }}
+                        transition={{ duration: limitTime, ease: 'linear' }}
                     ></motion.div>
                     <div />
                 </Progress>

--- a/frontend/src/hooks/useResultSketchbook.tsx
+++ b/frontend/src/hooks/useResultSketchbook.tsx
@@ -46,7 +46,7 @@ function useResultSketchbook(controlOnLocal: boolean) {
     }, []);
 
     useEffect(() => {
-        if (isStarted || isWatched) return;
+        if (isStarted || isWatched || controlOnLocal) return;
         setTimerTime(aSketchBookLimitTime);
     }, [currentBookIdx, isStarted, isWatched]);
 

--- a/frontend/src/hooks/useResultSketchbook.tsx
+++ b/frontend/src/hooks/useResultSketchbook.tsx
@@ -35,12 +35,15 @@ function useResultSketchbook(controlOnLocal: boolean) {
     });
 
     useEffect(() => {
-        if (!controlOnLocal) {
-            setTimeout(() => setIsStarted(false), 3000);
-        } else {
+        // 결과 공유 페이지일 경우 설명페이지 없이 바로 결과만 볼 수 있도록 한다.
+        if (controlOnLocal) {
             setIsStarted(false);
+            return;
         }
+
+        setTimeout(() => setIsStarted(false), 3000);
         onWatchResultSketchBook(setCurrentBookIdx, setCurrentPageIdx, setIsWatched);
+
         // 가장 처음 나타나는 스케치북도 봤다고 서버에게 알린다.
         if (isHost && !controlOnLocal) emitWatchResultSketchBook(0);
     }, []);


### PR DESCRIPTION
## 상세내용
- 타이머 애니메이션이 처음에는 느리게 진행되다가 뒤로 갈수록 빨라지지 않고 일관되게 진행되도록 linear를 적용했어요.
- 결과 공유 페이지에서 자동으로 페이지가 넘어가는 기능이 동작하지 않도록 수정했어요.
- 결과 공유 페이지와 게임이 전부 열려있으면 방장이 보는 스케치북과 결과공유 스케치북이 동기화되는 문제를 수정했어요. 