### PR TITLE
[feat] 그리기 도구 펜으로 초기화

### DIFF
--- a/frontend/src/hooks/usePalette.ts
+++ b/frontend/src/hooks/usePalette.ts
@@ -43,6 +43,7 @@ function usePalette({
         onClickColor(PEN_DEFAULT_COLOR);
         onClickLineWidth(1);
         onChangeTool(ToolsType.PEN);
+        onClickPen();
     }, []);
 
     const isSelectedTool = (type: ToolsType) => selectedTool === type;


### PR DESCRIPTION
## 상세내용
- 이전 라운드에서 사용했던 그리기 도구가 유지되던 버그를 해결했어요.
