### PR TITLE
[fix] 제출버튼을 누르지 않으면 다음 라운드로 넘어가지 않는 버그 수정 

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.1",
             "license": "UNLICENSED",
             "dependencies": {
+                "@nestjs/bull": "^0.6.2",
                 "@nestjs/common": "^9.2.1",
                 "@nestjs/config": "^2.2.0",
                 "@nestjs/core": "^9.2.1",
@@ -19,6 +20,7 @@
                 "@nestjs/websockets": "^9.2.0",
                 "@notionhq/client": "^2.2.2",
                 "@socket.io/redis-adapter": "^7.2.0",
+                "bull": "^4.10.2",
                 "cache-manager": "^5.1.3",
                 "cache-manager-redis-store": "^3.0.1",
                 "class-transformer": "^0.5.1",
@@ -36,6 +38,7 @@
                 "@nestjs/cli": "^9.0.0",
                 "@nestjs/schematics": "^9.0.0",
                 "@nestjs/testing": "^9.0.0",
+                "@types/bull": "^4.10.0",
                 "@types/cron": "^2.0.0",
                 "@types/express": "^4.17.13",
                 "@types/jest": "28.1.8",
@@ -1948,6 +1951,11 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
         },
+        "node_modules/@ioredis/commands": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+            "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+        },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2478,6 +2486,104 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "3.1.0",
                 "@jridgewell/sourcemap-codec": "1.4.14"
+            }
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.2.0.tgz",
+            "integrity": "sha512-Z9LFPzfoJi4mflGWV+rv7o7ZbMU5oAU9VmzCgL240KnqDW65Y2HFCT3MW06/ITJSnbVLacmcEJA8phywK7JinQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.2.0.tgz",
+            "integrity": "sha512-vq0tT8sjZsy4JdSqmadWVw6f66UXqUCabLmUVHZwUFzMgtgoIIQjT4VVRHKvlof3P/dMCkbMJ5hB1oJ9OWHaaw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.2.0.tgz",
+            "integrity": "sha512-SaJ3Qq4lX9Syd2xEo9u3qPxi/OB+5JO/ngJKK97XDpa1C587H9EWYO6KD8995DAjSinWvdHKRrCOXVUC5fvGOg==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.2.0.tgz",
+            "integrity": "sha512-hlxxLdRmPyq16QCutUtP8Tm6RDWcyaLsRssaHROatgnkOxdleMTgetf9JsdncL8vLh7FVy/RN9i3XR5dnb9cRA==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.2.0.tgz",
+            "integrity": "sha512-94y5PJrSOqUNcFKmOl7z319FelCLAE0rz/jPCWS+UtdMZvpa4jrQd+cJPQCLp2Fes1yAW/YUQj/Di6YVT3c3Iw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.2.0.tgz",
+            "integrity": "sha512-XrC0JzsqQSvOyM3t04FMLO6z5gCuhPE6k4FXuLK5xf52ZbdvcFe1yBmo7meCew9B8G2f0T9iu9t3kfTYRYROgA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@nestjs/bull": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@nestjs/bull/-/bull-0.6.2.tgz",
+            "integrity": "sha512-tx5wiIGgfYEj5RAJA1B23pn/63nsmMH0f981V1/v3NKyE07NsvOXCrwKNGQnIZZlXkXh7lgx2I80/tYwPGnVIg==",
+            "dependencies": {
+                "@nestjs/bull-shared": "^0.1.2",
+                "tslib": "2.4.1"
+            },
+            "peerDependencies": {
+                "@nestjs/common": "^6.10.11 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+                "@nestjs/core": "^6.10.11 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+                "bull": "^3.3 || ^4.0.0"
+            }
+        },
+        "node_modules/@nestjs/bull-shared": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@nestjs/bull-shared/-/bull-shared-0.1.2.tgz",
+            "integrity": "sha512-q1JqieWb2YjA6OIal5XjtbF28LgJxEflwJB9x3OnE2OUgI0kWvaMlYMaW3opFmgcWPjx4o5lVhcGnwXeIhZfgg==",
+            "dependencies": {
+                "tslib": "2.4.1"
+            },
+            "peerDependencies": {
+                "@nestjs/common": "^6.10.11 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+                "@nestjs/core": "^6.10.11 || ^7.0.0 || ^8.0.0 || ^9.0.0"
             }
         },
         "node_modules/@nestjs/cli": {
@@ -3135,6 +3241,16 @@
             "dependencies": {
                 "@types/connect": "*",
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/bull": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@types/bull/-/bull-4.10.0.tgz",
+            "integrity": "sha512-RkYW8K2H3J76HT6twmHYbzJ0GtLDDotpLP9ah9gtiA7zfF6peBH1l5fEiK0oeIZ3/642M7Jcb9sPmor8Vf4w6g==",
+            "deprecated": "This is a stub types definition. bull provides its own type definitions, so you do not need this installed.",
+            "dev": true,
+            "dependencies": {
+                "bull": "*"
             }
         },
         "node_modules/@types/connect": {
@@ -4284,6 +4400,33 @@
                 "semver": "^7.0.0"
             }
         },
+        "node_modules/bull": {
+            "version": "4.10.2",
+            "resolved": "https://registry.npmjs.org/bull/-/bull-4.10.2.tgz",
+            "integrity": "sha512-xa65xtWjQsLqYU/eNaXxq9VRG8xd6qNsQEjR7yjYuae05xKrzbVMVj2QgrYsTMmSs/vsqJjHqHSRRiW1+IkGXQ==",
+            "dependencies": {
+                "cron-parser": "^4.2.1",
+                "debuglog": "^1.0.0",
+                "get-port": "^5.1.1",
+                "ioredis": "^5.0.0",
+                "lodash": "^4.17.21",
+                "msgpackr": "^1.5.2",
+                "p-timeout": "^3.2.0",
+                "semver": "^7.3.2",
+                "uuid": "^8.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/bull/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
         "node_modules/busboy": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -4716,6 +4859,25 @@
                 "luxon": "^1.23.x"
             }
         },
+        "node_modules/cron-parser": {
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.7.1.tgz",
+            "integrity": "sha512-WguFaoQ0hQ61SgsCZLHUcNbAvlK0lypKXu62ARguefYmjzaOXIVRNrAmyXzabTwUn4sQvQLkk6bjH+ipGfw8bA==",
+            "dependencies": {
+                "luxon": "^3.2.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/cron-parser/node_modules/luxon": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+            "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4743,6 +4905,14 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/debuglog": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/dedent": {
@@ -4799,6 +4969,14 @@
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/denque": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+            "engines": {
+                "node": ">=0.10"
             }
         },
         "node_modules/depd": {
@@ -6169,6 +6347,17 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/get-port": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+            "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-stream": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -6553,6 +6742,29 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10"
+            }
+        },
+        "node_modules/ioredis": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.2.5.tgz",
+            "integrity": "sha512-7HKo/ClM2DGLRXdFq8ruS3Uuadensz4A76wPOU0adqlOqd1qkhoLPDaBhmVhUhNGpB+J65/bhLmNB8DDY99HJQ==",
+            "dependencies": {
+                "@ioredis/commands": "^1.1.1",
+                "cluster-key-slot": "^1.1.0",
+                "debug": "^4.3.4",
+                "denque": "^2.0.1",
+                "lodash.defaults": "^4.2.0",
+                "lodash.isarguments": "^3.1.0",
+                "redis-errors": "^1.2.0",
+                "redis-parser": "^3.0.0",
+                "standard-as-callback": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ioredis"
             }
         },
         "node_modules/ip": {
@@ -7896,6 +8108,16 @@
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
             "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
         },
+        "node_modules/lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+        },
+        "node_modules/lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8261,6 +8483,35 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
+        "node_modules/msgpackr": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.1.tgz",
+            "integrity": "sha512-05fT4J8ZqjYlR4QcRDIhLCYKUOHXk7C/xa62GzMKj74l3up9k2QZ3LgFc6qWdsPHl91QA2WLWqWc8b8t7GLNNw==",
+            "optionalDependencies": {
+                "msgpackr-extract": "^2.2.0"
+            }
+        },
+        "node_modules/msgpackr-extract": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.2.0.tgz",
+            "integrity": "sha512-0YcvWSv7ZOGl9Od6Y5iJ3XnPww8O7WLcpYMDwX+PAA/uXLDtyw94PJv9GLQV/nnp3cWlDhMoyKZIQLrx33sWog==",
+            "hasInstallScript": true,
+            "optional": true,
+            "dependencies": {
+                "node-gyp-build-optional-packages": "5.0.3"
+            },
+            "bin": {
+                "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+            },
+            "optionalDependencies": {
+                "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.2.0",
+                "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.2.0",
+                "@msgpackr-extract/msgpackr-extract-linux-arm": "2.2.0",
+                "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.2.0",
+                "@msgpackr-extract/msgpackr-extract-linux-x64": "2.2.0",
+                "@msgpackr-extract/msgpackr-extract-win32-x64": "2.2.0"
+            }
+        },
         "node_modules/multer": {
             "version": "1.4.4-lts.1",
             "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.4-lts.1.tgz",
@@ -8339,6 +8590,17 @@
                 "encoding": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/node-gyp-build-optional-packages": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+            "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+            "optional": true,
+            "bin": {
+                "node-gyp-build-optional-packages": "bin.js",
+                "node-gyp-build-optional-packages-optional": "optional.js",
+                "node-gyp-build-optional-packages-test": "build-test.js"
             }
         },
         "node_modules/node-int64": {
@@ -8560,6 +8822,14 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8586,6 +8856,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-timeout": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+            "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+            "dependencies": {
+                "p-finally": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/p-try": {
@@ -9007,6 +9288,25 @@
                 "@redis/json": "1.0.4",
                 "@redis/search": "1.1.0",
                 "@redis/time-series": "1.0.4"
+            }
+        },
+        "node_modules/redis-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/redis-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+            "dependencies": {
+                "redis-errors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/reflect-metadata": {
@@ -9562,6 +9862,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/standard-as-callback": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+            "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
         },
         "node_modules/statuses": {
             "version": "2.0.1",
@@ -12236,6 +12541,11 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
         },
+        "@ioredis/commands": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+            "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+        },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -12653,6 +12963,59 @@
             "requires": {
                 "@jridgewell/resolve-uri": "3.1.0",
                 "@jridgewell/sourcemap-codec": "1.4.14"
+            }
+        },
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.2.0.tgz",
+            "integrity": "sha512-Z9LFPzfoJi4mflGWV+rv7o7ZbMU5oAU9VmzCgL240KnqDW65Y2HFCT3MW06/ITJSnbVLacmcEJA8phywK7JinQ==",
+            "optional": true
+        },
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.2.0.tgz",
+            "integrity": "sha512-vq0tT8sjZsy4JdSqmadWVw6f66UXqUCabLmUVHZwUFzMgtgoIIQjT4VVRHKvlof3P/dMCkbMJ5hB1oJ9OWHaaw==",
+            "optional": true
+        },
+        "@msgpackr-extract/msgpackr-extract-linux-arm": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.2.0.tgz",
+            "integrity": "sha512-SaJ3Qq4lX9Syd2xEo9u3qPxi/OB+5JO/ngJKK97XDpa1C587H9EWYO6KD8995DAjSinWvdHKRrCOXVUC5fvGOg==",
+            "optional": true
+        },
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.2.0.tgz",
+            "integrity": "sha512-hlxxLdRmPyq16QCutUtP8Tm6RDWcyaLsRssaHROatgnkOxdleMTgetf9JsdncL8vLh7FVy/RN9i3XR5dnb9cRA==",
+            "optional": true
+        },
+        "@msgpackr-extract/msgpackr-extract-linux-x64": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.2.0.tgz",
+            "integrity": "sha512-94y5PJrSOqUNcFKmOl7z319FelCLAE0rz/jPCWS+UtdMZvpa4jrQd+cJPQCLp2Fes1yAW/YUQj/Di6YVT3c3Iw==",
+            "optional": true
+        },
+        "@msgpackr-extract/msgpackr-extract-win32-x64": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.2.0.tgz",
+            "integrity": "sha512-XrC0JzsqQSvOyM3t04FMLO6z5gCuhPE6k4FXuLK5xf52ZbdvcFe1yBmo7meCew9B8G2f0T9iu9t3kfTYRYROgA==",
+            "optional": true
+        },
+        "@nestjs/bull": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@nestjs/bull/-/bull-0.6.2.tgz",
+            "integrity": "sha512-tx5wiIGgfYEj5RAJA1B23pn/63nsmMH0f981V1/v3NKyE07NsvOXCrwKNGQnIZZlXkXh7lgx2I80/tYwPGnVIg==",
+            "requires": {
+                "@nestjs/bull-shared": "^0.1.2",
+                "tslib": "2.4.1"
+            }
+        },
+        "@nestjs/bull-shared": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@nestjs/bull-shared/-/bull-shared-0.1.2.tgz",
+            "integrity": "sha512-q1JqieWb2YjA6OIal5XjtbF28LgJxEflwJB9x3OnE2OUgI0kWvaMlYMaW3opFmgcWPjx4o5lVhcGnwXeIhZfgg==",
+            "requires": {
+                "tslib": "2.4.1"
             }
         },
         "@nestjs/cli": {
@@ -13122,6 +13485,15 @@
             "requires": {
                 "@types/connect": "*",
                 "@types/node": "*"
+            }
+        },
+        "@types/bull": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@types/bull/-/bull-4.10.0.tgz",
+            "integrity": "sha512-RkYW8K2H3J76HT6twmHYbzJ0GtLDDotpLP9ah9gtiA7zfF6peBH1l5fEiK0oeIZ3/642M7Jcb9sPmor8Vf4w6g==",
+            "dev": true,
+            "requires": {
+                "bull": "*"
             }
         },
         "@types/connect": {
@@ -14026,6 +14398,29 @@
                 "semver": "^7.0.0"
             }
         },
+        "bull": {
+            "version": "4.10.2",
+            "resolved": "https://registry.npmjs.org/bull/-/bull-4.10.2.tgz",
+            "integrity": "sha512-xa65xtWjQsLqYU/eNaXxq9VRG8xd6qNsQEjR7yjYuae05xKrzbVMVj2QgrYsTMmSs/vsqJjHqHSRRiW1+IkGXQ==",
+            "requires": {
+                "cron-parser": "^4.2.1",
+                "debuglog": "^1.0.0",
+                "get-port": "^5.1.1",
+                "ioredis": "^5.0.0",
+                "lodash": "^4.17.21",
+                "msgpackr": "^1.5.2",
+                "p-timeout": "^3.2.0",
+                "semver": "^7.3.2",
+                "uuid": "^8.3.0"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                }
+            }
+        },
         "busboy": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -14352,6 +14747,21 @@
                 "luxon": "^1.23.x"
             }
         },
+        "cron-parser": {
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.7.1.tgz",
+            "integrity": "sha512-WguFaoQ0hQ61SgsCZLHUcNbAvlK0lypKXu62ARguefYmjzaOXIVRNrAmyXzabTwUn4sQvQLkk6bjH+ipGfw8bA==",
+            "requires": {
+                "luxon": "^3.2.1"
+            },
+            "dependencies": {
+                "luxon": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+                    "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
+                }
+            }
+        },
         "cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -14369,6 +14779,11 @@
             "requires": {
                 "ms": "2.1.2"
             }
+        },
+        "debuglog": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw=="
         },
         "dedent": {
             "version": "0.7.0",
@@ -14410,6 +14825,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+        },
+        "denque": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
         },
         "depd": {
             "version": "2.0.0",
@@ -15428,6 +15848,11 @@
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "dev": true
         },
+        "get-port": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+            "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
+        },
         "get-stream": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -15693,6 +16118,22 @@
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true
+        },
+        "ioredis": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.2.5.tgz",
+            "integrity": "sha512-7HKo/ClM2DGLRXdFq8ruS3Uuadensz4A76wPOU0adqlOqd1qkhoLPDaBhmVhUhNGpB+J65/bhLmNB8DDY99HJQ==",
+            "requires": {
+                "@ioredis/commands": "^1.1.1",
+                "cluster-key-slot": "^1.1.0",
+                "debug": "^4.3.4",
+                "denque": "^2.0.1",
+                "lodash.defaults": "^4.2.0",
+                "lodash.isarguments": "^3.1.0",
+                "redis-errors": "^1.2.0",
+                "redis-parser": "^3.0.0",
+                "standard-as-callback": "^2.1.0"
+            }
         },
         "ip": {
             "version": "2.0.0",
@@ -16688,6 +17129,16 @@
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
             "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
         },
+        "lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+        },
+        "lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -16959,6 +17410,29 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
+        "msgpackr": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.1.tgz",
+            "integrity": "sha512-05fT4J8ZqjYlR4QcRDIhLCYKUOHXk7C/xa62GzMKj74l3up9k2QZ3LgFc6qWdsPHl91QA2WLWqWc8b8t7GLNNw==",
+            "requires": {
+                "msgpackr-extract": "^2.2.0"
+            }
+        },
+        "msgpackr-extract": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.2.0.tgz",
+            "integrity": "sha512-0YcvWSv7ZOGl9Od6Y5iJ3XnPww8O7WLcpYMDwX+PAA/uXLDtyw94PJv9GLQV/nnp3cWlDhMoyKZIQLrx33sWog==",
+            "optional": true,
+            "requires": {
+                "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.2.0",
+                "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.2.0",
+                "@msgpackr-extract/msgpackr-extract-linux-arm": "2.2.0",
+                "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.2.0",
+                "@msgpackr-extract/msgpackr-extract-linux-x64": "2.2.0",
+                "@msgpackr-extract/msgpackr-extract-win32-x64": "2.2.0",
+                "node-gyp-build-optional-packages": "5.0.3"
+            }
+        },
         "multer": {
             "version": "1.4.4-lts.1",
             "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.4-lts.1.tgz",
@@ -17021,6 +17495,12 @@
             "requires": {
                 "whatwg-url": "^5.0.0"
             }
+        },
+        "node-gyp-build-optional-packages": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+            "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+            "optional": true
         },
         "node-int64": {
             "version": "0.4.0",
@@ -17180,6 +17660,11 @@
             "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
             "dev": true
         },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
+        },
         "p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -17194,6 +17679,14 @@
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "requires": {
                 "p-limit": "^3.0.2"
+            }
+        },
+        "p-timeout": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+            "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+            "requires": {
+                "p-finally": "^1.0.0"
             }
         },
         "p-try": {
@@ -17499,6 +17992,19 @@
                 "@redis/json": "1.0.4",
                 "@redis/search": "1.1.0",
                 "@redis/time-series": "1.0.4"
+            }
+        },
+        "redis-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="
+        },
+        "redis-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+            "requires": {
+                "redis-errors": "^1.0.0"
             }
         },
         "reflect-metadata": {
@@ -17911,6 +18417,11 @@
                     "dev": true
                 }
             }
+        },
+        "standard-as-callback": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+            "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
         },
         "statuses": {
             "version": "2.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
         "test:e2e": "jest --config ./test/jest-e2e.json"
     },
     "dependencies": {
+        "@nestjs/bull": "^0.6.2",
         "@nestjs/common": "^9.2.1",
         "@nestjs/config": "^2.2.0",
         "@nestjs/core": "^9.2.1",
@@ -32,6 +33,7 @@
         "@nestjs/websockets": "^9.2.0",
         "@notionhq/client": "^2.2.2",
         "@socket.io/redis-adapter": "^7.2.0",
+        "bull": "^4.10.2",
         "cache-manager": "^5.1.3",
         "cache-manager-redis-store": "^3.0.1",
         "class-transformer": "^0.5.1",
@@ -49,6 +51,7 @@
         "@nestjs/cli": "^9.0.0",
         "@nestjs/schematics": "^9.0.0",
         "@nestjs/testing": "^9.0.0",
+        "@types/bull": "^4.10.0",
         "@types/cron": "^2.0.0",
         "@types/express": "^4.17.13",
         "@types/jest": "28.1.8",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { RedisModule } from './redis/redis.module';
 import { MongooseModule } from '@nestjs/mongoose';
 import { ConfigModule } from '@nestjs/config';
 import { AdminModule } from './admin/admin.module';
+import { QueueModule } from './bull/queue.module';
 
 @Module({
     imports: [
@@ -15,6 +16,9 @@ import { AdminModule } from './admin/admin.module';
         ConfigModule.forRoot(),
         ...(process.env.NODE_APP_INSTANCE === '0' && process.env.NODE_ENV === 'production'
             ? [AdminModule]
+            : []),
+        ...(process.env.NODE_APP_INSTANCE === '0' || process.env.NODE_APP_INSTANCE === undefined
+            ? [QueueModule]
             : []),
     ],
     controllers: [AppController],

--- a/backend/src/bull/queue.module.ts
+++ b/backend/src/bull/queue.module.ts
@@ -1,0 +1,15 @@
+import { BullModule } from '@nestjs/bull';
+import { Module } from '@nestjs/common';
+import { CoreProcessor } from './queue.processor';
+import { CoreModule } from '../core/core.module';
+
+@Module({
+    imports: [
+        CoreModule,
+        BullModule.registerQueue({
+            name: 'core',
+        }),
+    ],
+    providers: [CoreProcessor],
+})
+export class QueueModule {}

--- a/backend/src/bull/queue.processor.ts
+++ b/backend/src/bull/queue.processor.ts
@@ -1,0 +1,29 @@
+import { Process, Processor } from '@nestjs/bull';
+import { Job } from 'bull';
+import { GameService } from '../core/game.service';
+import { CoreGateway } from '../core/core.gateway';
+
+@Processor('core')
+export class CoreProcessor {
+    constructor(
+        private readonly gameService: GameService,
+        private readonly coreGateway: CoreGateway,
+    ) {}
+
+    @Process('submit-quiz-reply')
+    async handleTranscode(job: Job) {
+        await this.gameService.submitQuizReply(
+            job.data.user.lobbyId,
+            job.data.user,
+            job.data.request.quizReply,
+        );
+        if (await this.gameService.isAllUserSubmittedQuizReply(job.data.user.lobbyId)) {
+            await this.coreGateway.proceedRound(job.data.user);
+        } else {
+            const repliesCount = await this.gameService.getSubmittedQuizRepliesCount(
+                job.data.user.lobbyId,
+            );
+            this.coreGateway.broadCastQuizReplySubmitted(repliesCount, job.data.user);
+        }
+    }
+}

--- a/backend/src/core/core.gateway.ts
+++ b/backend/src/core/core.gateway.ts
@@ -6,8 +6,9 @@ import {
     OnGatewayDisconnect,
     SubscribeMessage,
     WebSocketGateway,
+    WebSocketServer,
 } from '@nestjs/websockets';
-import { Socket } from 'socket.io';
+import { Server, Socket } from 'socket.io';
 import { LobbyService } from './lobby.service';
 import { UseFilters, UsePipes, ValidationPipe } from '@nestjs/common';
 import {
@@ -38,6 +39,9 @@ import { User } from './user.model';
 @UseFilters(new SocketExceptionFilter())
 @WebSocketGateway(8180, { namespace: 'core' })
 export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
+    @WebSocketServer()
+    server: Server;
+
     constructor(
         private readonly lobbyService: LobbyService,
         private readonly gameService: GameService,
@@ -93,7 +97,7 @@ export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
             const users: User[] = await this.lobbyService.joinLobby(user, lobby.id);
             await client.join(body.lobbyId);
-            this.emitJoinLobby(client, lobby.id, {
+            this.emitJoinLobby(lobby.id, {
                 userName: user.name,
                 sid: client.id,
                 audio: user.audio,
@@ -119,7 +123,7 @@ export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
         const user = await this.userService.getUser(client.id);
         if (user.lobbyId === undefined) return;
 
-        await this.handleHostLeave(client, user);
+        await this.handleHostLeave(user);
         await this.lobbyService.leaveLobby(user, user.lobbyId);
         const payload = {
             userName: user.name,
@@ -134,13 +138,13 @@ export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
         const user = await this.userService.getUser(client.id);
         if (user.lobbyId === undefined) return;
 
-        await this.handleHostLeave(client, user);
+        await this.handleHostLeave(user);
         await this.gameService.leaveWhenPlayingGame(user, user.lobbyId);
-        this.emitLeaveGame(client, user);
+        this.emitLeaveGame(user.lobbyId, user);
         await client.leave(user.lobbyId);
     }
 
-    async handleHostLeave(client: Socket, user: User) {
+    async handleHostLeave(user: User) {
         const isGameHost = await this.gameService.isHost(user.lobbyId, user);
         if (!isGameHost) return;
         const numOfUsersInLobby = await this.lobbyService.getNumOfUsers(user.lobbyId);
@@ -152,7 +156,7 @@ export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
             userName: hostUser.name,
             sid: hostUser.getId(),
         };
-        client.to(user.lobbyId).emit('succeed-host', payload);
+        this.server.to(user.lobbyId).emit('succeed-host', payload);
     }
 
     @SubscribeMessage('start-game')
@@ -163,8 +167,8 @@ export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
         await this.gameService.startGame(lobbyId);
 
-        this.emitStartGame(client, lobbyId);
-        await this.emitStartRound(client, lobbyId);
+        this.emitStartGame(lobbyId);
+        await this.emitStartRound(lobbyId);
     }
 
     @SubscribeMessage('submit-quiz-reply')
@@ -177,25 +181,25 @@ export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
         await this.gameService.submitQuizReply(user.lobbyId, user, request.quizReply);
         const repliesCount = await this.gameService.getSubmittedQuizRepliesCount(user.lobbyId);
         if (await this.gameService.isAllUserSubmittedQuizReply(user.lobbyId)) {
-            await this.proceedRound(user, client);
+            await this.proceedRound(user);
         } else {
             this.broadCastQuizReplySubmitted(repliesCount, client, user);
         }
     }
 
-    private broadCastQuizReplySubmitted(repliesCount: number, client: Socket, user: User) {
+    private broadCastQuizReplySubmitted(repliesCount: number, user: User) {
         const payload = new SubmitQuizReplyEmitRequest(repliesCount);
-        this.emitSubmitQuizReply(client, user.lobbyId, payload);
+        this.emitSubmitQuizReply(user.lobbyId, payload);
     }
 
-    private async proceedRound(user: User, client: Socket) {
+    private async proceedRound(user: User) {
         if (await this.gameService.isLastRound(user.lobbyId)) {
             const game = await this.gameService.getGame(user.lobbyId);
             const resultShareId = await this.gameResultService.create(game);
-            await this.emitCompleteGame(client, user.lobbyId, resultShareId);
+            await this.emitCompleteGame(user.lobbyId, resultShareId);
         } else {
             await this.gameService.proceedRound(user.lobbyId);
-            await this.emitStartRound(client, user.lobbyId);
+            await this.emitStartRound(user.lobbyId);
         }
     }
 
@@ -243,7 +247,7 @@ export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
             payload.bookIdx,
         );
         await this.gameService.watchQuizReplyChain(user.lobbyId, payload.bookIdx);
-        this.emitWatchResultSketchbook(client, payload.bookIdx, isWatched);
+        this.emitWatchResultSketchbook(user.lobbyId, payload.bookIdx, isWatched);
     }
 
     @SubscribeMessage('back-to-lobby')
@@ -251,27 +255,27 @@ export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
         const user = await this.userService.getUser(client.id);
         await this.gameService.quitGame(user.lobbyId);
 
-        this.emitBackToLobby(client);
+        this.emitBackToLobby(user.lobbyId);
     }
 
-    private emitWatchResultSketchbook(client: Socket, bookIndex: number, isWatched: boolean) {
+    private emitWatchResultSketchbook(lobbyId: string, bookIndex: number, isWatched: boolean) {
         const payload = new WatchResultSketchbookEmitRequest(bookIndex, isWatched);
-        client.nsp.emit('watch-result-sketchbook', payload);
+        this.server.to(lobbyId).emit('watch-result-sketchbook', payload);
     }
 
-    private emitJoinLobby(client: Socket, lobbyId: string, payload: JoinLobbyReEmitRequest) {
-        client.to(lobbyId).emit('join-lobby', payload);
+    private emitJoinLobby(lobbyId: string, payload: JoinLobbyReEmitRequest) {
+        this.server.to(lobbyId).emit('join-lobby', payload);
     }
 
-    private emitLeaveLobby(client: Socket, lobbyId: string, payload: JoinLobbyReEmitRequest[]) {
-        client.broadcast.to(lobbyId).emit('leave-lobby', payload);
+    private emitLeaveLobby(lobbyId: string, payload: JoinLobbyReEmitRequest[]) {
+        this.server.to(lobbyId).emit('leave-lobby', payload);
     }
 
-    private emitStartGame(client: Socket, lobbyId: string) {
-        client.nsp.to(lobbyId).emit('start-game');
+    private emitStartGame(lobbyId: string) {
+        this.server.to(lobbyId).emit('start-game');
     }
 
-    private async emitStartRound(client: Socket, lobbyId: string) {
+    private async emitStartRound(lobbyId: string) {
         const game = await this.gameService.getGame(lobbyId);
         for (const user of game.getUsers()) {
             const quizReply = (
@@ -285,12 +289,12 @@ export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
                 game.maxRound,
                 game.roundLimitTime,
             );
-            client.nsp.to(user.socketId).emit('start-round', payload);
+            this.server.to(user.socketId).emit('start-round', payload);
         }
-        await this.emitRoundTimeout(client, lobbyId);
+        await this.emitRoundTimeout(lobbyId);
     }
 
-    private async emitRoundTimeout(client: Socket, lobbyId: string) {
+    private async emitRoundTimeout(lobbyId: string) {
         const game = await this.gameService.getGame(lobbyId);
         const roundWhenTimerStart = game.getCurRound();
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -300,7 +304,7 @@ export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
                 (await this.gameService.getNotSubmittedUsers(lobbyId)).forEach((user, index) => {
                     // TODO: 동시성 이슈 해결하여 timeout 걷어내기
                     setTimeout(() => {
-                        client.nsp.to(user.socketId).emit('round-timeout');
+                        this.server.to(user.socketId).emit('round-timeout');
                     }, index * 100);
                 });
             } catch (e) {
@@ -309,15 +313,11 @@ export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
         }, game.getRoundLimitTime() * 1000);
     }
 
-    private emitSubmitQuizReply(
-        client: Socket,
-        lobbyId: string,
-        payload: SubmitQuizReplyEmitRequest,
-    ) {
-        client.nsp.to(lobbyId).emit('submit-quiz-reply', payload);
+    private emitSubmitQuizReply(lobbyId: string, payload: SubmitQuizReplyEmitRequest) {
+        this.server.to(lobbyId).emit('submit-quiz-reply', payload);
     }
 
-    private async emitCompleteGame(client: Socket, lobbyId: string, gameResultId: string) {
+    private async emitCompleteGame(lobbyId: string, gameResultId: string) {
         const quizReplyChains: QuizReplyChain[] =
             await this.gameService.getQuizReplyChainsWhenGameEnd(lobbyId);
         const payload = new CompleteGameEmitRequest(
@@ -325,15 +325,16 @@ export class CoreGateway implements OnGatewayConnection, OnGatewayDisconnect {
             quizReplyChains.map((quizReplyChain) => quizReplyChain.quizReplyList),
         );
 
-        client.nsp.to(lobbyId).emit('complete-game', payload);
+        this.server.to(lobbyId).emit('complete-game', payload);
     }
 
-    private emitLeaveGame(client: Socket, user: User) {
-        const payload = new EmitLeaveGameRequest(user.name, client.id);
-        client.nsp.to(user.lobbyId).emit('leave-game', payload);
+    private emitLeaveGame(lobbyId: string, user: User) {
+        // TODO: EmitLeaveGameRequest 생성자 파라미터 순서 수정
+        const payload = new EmitLeaveGameRequest(user.name, user.socketId);
+        this.server.to(lobbyId).emit('leave-game', payload);
     }
 
-    private emitBackToLobby(client: Socket) {
-        client.nsp.emit('back-to-lobby');
+    private emitBackToLobby(lobbyId: string) {
+        this.server.to(lobbyId).emit('back-to-lobby');
     }
 }

--- a/backend/src/core/core.module.ts
+++ b/backend/src/core/core.module.ts
@@ -24,6 +24,6 @@ import { TestService } from './test.service';
         GameLobbyRepository,
         UserRepository,
     ],
-    exports: [UserService, LobbyService],
+    exports: [UserService, LobbyService, GameService, CoreGateway],
 })
 export class CoreModule {}

--- a/backend/src/core/core.module.ts
+++ b/backend/src/core/core.module.ts
@@ -7,7 +7,6 @@ import { GameLobbyRepository } from './gamelobby.repository';
 import { GameResultModule } from '../gameResult/gameResult.module';
 import { UserRepository } from './user.repository';
 import { BullModule } from '@nestjs/bull';
-import { TestService } from './test.service';
 
 @Module({
     imports: [

--- a/backend/src/core/core.module.ts
+++ b/backend/src/core/core.module.ts
@@ -6,9 +6,16 @@ import { GameService } from './game.service';
 import { GameLobbyRepository } from './gamelobby.repository';
 import { GameResultModule } from '../gameResult/gameResult.module';
 import { UserRepository } from './user.repository';
+import { BullModule } from '@nestjs/bull';
+import { TestService } from './test.service';
 
 @Module({
-    imports: [GameResultModule],
+    imports: [
+        GameResultModule,
+        BullModule.registerQueue({
+            name: 'core',
+        }),
+    ],
     providers: [
         CoreGateway,
         LobbyService,

--- a/backend/src/redis/redis.module.ts
+++ b/backend/src/redis/redis.module.ts
@@ -1,5 +1,6 @@
 import { CacheModule, Module } from '@nestjs/common';
 import { redisStore } from 'cache-manager-redis-store';
+import { BullModule } from '@nestjs/bull';
 
 @Module({
     imports: [
@@ -14,6 +15,12 @@ import { redisStore } from 'cache-manager-redis-store';
                 return {
                     store: () => store,
                 };
+            },
+        }),
+        BullModule.forRoot({
+            redis: {
+                host: 'localhost',
+                port: 6379,
             },
         }),
     ],


### PR DESCRIPTION
## 상세내용
#109  이슈 해결
게임 유저들이 제출 버튼을 모두 누르지 않은 상황에서 타임아웃이 되면, 다음 라운드로 넘어가지지 않는 버그가 있어요.

## 기존 상황

round timeout → client 들에게 답안 제출 요청 → 다수의 클라이언트가 동시에 submit-quiz-reply 이벤트 전송 → 서버에서 submit-quiz-reply 동시 처리

**예상 실행** 

- 한 클라이언트의 submit-quiz-reply 이벤트 핸들링이 끝나면 다음 클라이언트의 submit-quiz-reply 이벤트를 핸들링한다.
- read & write → read & write → read & write

**실제 실행**

- 이벤트 핸들링의 순서 보장이 되지 않는다.
- 이벤트 핸들링 로직에 비동기 로직(DB operation)이 있기 때문.
- read, read, read, write, write, write

## 해결 방법

1. redis transaction을 사용한다.
    
    → read 와 write 사이에 application layer에서 로직을 실행해야 한다
    
    → db 실행의 최소단위가 될 수 없다.
    
    → 된다고 하더라도 redis에 병목을 주게 될 것이다.
    
2. message queue를 사용한다.
    → 이벤트 핸들링 시 Job(=Task)을 queue에 enqueue 하고, 순서대로 dequeue 하면서 처리한다.
    → 각각의 Job이 Atomic 해 지므로 순서가 보장된다.
    → [Bull](https://github.com/OptimalBits/bull#bull-features) 라이브러리 사용하여 구현한다. (Redis의 queue 를 사용하는 라이브러리)
    
## 결과

enqueue 하고 dequeue 이후 프로세스가 마칠 때 까지 기다린다. 마치게 되면 dequeue한다.

→ 기존에 이벤트 핸들링을 동시에 처리했었지만 , queue 에 넣고 사용하므로써 하나의 Job을 atomic 하게 관리할 수 있다. 따라서 순서를 보장할 수 있다.

queue의 job 핸들러가 여러개이면, 동시에 queue에서 dequeue 해 Job을 처리할 수 있기 때문에 클러스터의 인스턴스 중 0 번 인스턴스만 queue를 핸들링하도록 구현하였다.
-> 만약 부하가 심해 여러개의 스레드에서 처리되도록 해야 한다면 Bull 에서 제공하는 cluster 기능을 시도해볼만 하다!